### PR TITLE
fix(inbox-desktop): add print preview window with CSP-safe toolbar (#…

### DIFF
--- a/applications/inbox-desktop/src/utils/printing/print.ts
+++ b/applications/inbox-desktop/src/utils/printing/print.ts
@@ -13,9 +13,93 @@ type PrintAction = (window: BrowserWindow) => Promise<void>;
 export const PRINT_DATA_URL_PREFIX = "data:text/html;charset=utf-8,";
 export const validPrintContent = new Set<string>();
 
+const PREVIEW_ACTION_PRINT = "https://proton-mail-print.invalid/print";
+const PREVIEW_ACTION_SAVE_PDF = "https://proton-mail-print.invalid/save-pdf";
+const PREVIEW_ACTION_CLOSE = "https://proton-mail-print.invalid/close";
+
+// Toolbar injected at the top of the preview document. The buttons carry only
+// a data-action attribute; their click handlers are attached from the main
+// process (see showPreviewWindow) rather than via inline onclick, so they are
+// not subject to the rendered email's Content-Security-Policy.
+const PREVIEW_TOOLBAR = `
+<style>
+  #proton-print-toolbar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 50px;
+    background: #ffffff;
+    border-bottom: 1px solid #e0e0e0;
+    display: flex;
+    align-items: center;
+    padding: 0 20px;
+    gap: 10px;
+    z-index: 2147483647;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  }
+  #proton-print-toolbar .toolbar-title {
+    flex: 1;
+    font-size: 14px;
+    font-weight: 600;
+    color: #1a1a1a;
+  }
+  #proton-print-toolbar button {
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 7px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  #proton-print-toolbar .btn-print {
+    background: #2563eb;
+    color: #ffffff;
+    border: none;
+  }
+  #proton-print-toolbar .btn-pdf {
+    background: #ffffff;
+    color: #1a1a1a;
+    border: 1px solid #d0d0d0;
+  }
+  #proton-print-toolbar .btn-close {
+    background: #ffffff;
+    color: #1a1a1a;
+    border: 1px solid #d0d0d0;
+  }
+  body { margin-top: 58px !important; }
+</style>
+<div id="proton-print-toolbar">
+  <span class="toolbar-title">Print Preview</span>
+  <button class="btn-print" data-action="${PREVIEW_ACTION_PRINT}">Print</button>
+  <button class="btn-pdf" data-action="${PREVIEW_ACTION_SAVE_PDF}">Save as PDF</button>
+  <button class="btn-close" data-action="${PREVIEW_ACTION_CLOSE}">Close</button>
+</div>
+`;
+
+function injectPreviewToolbar(htmlContent: string): string {
+    if (/<body/i.test(htmlContent)) {
+        return htmlContent.replace(/<body([^>]*)>/i, `<body$1>${PREVIEW_TOOLBAR}`);
+    }
+    return PREVIEW_TOOLBAR + htmlContent;
+}
+
 const createPrintWindow = () => {
     return new BrowserWindow({
         show: false,
+        webPreferences: {
+            nodeIntegration: false,
+        },
+    });
+};
+
+const createPreviewWindow = () => {
+    return new BrowserWindow({
+        width: 800,
+        height: 900,
+        show: false,
+        title: "Print Preview",
         webPreferences: {
             nodeIntegration: false,
         },
@@ -147,26 +231,95 @@ async function printAndSaveToPDF(parentWindow: BrowserWindow, htmlContent: strin
     }
 }
 
-export function showPrintDialog(htmlContent: string) {
+async function showPreviewWindow(htmlContent: string): Promise<void> {
     const mainWindow = getMainWindow();
-    if (!isWindowValid(mainWindow)) return;
+    const previewWindow = createPreviewWindow();
+    const previewContent = injectPreviewToolbar(htmlContent);
 
-    dialog
-        .showMessageBox(mainWindow, {
-            type: "question",
-            buttons: ["Save as PDF", "Print", "Cancel"],
-            defaultId: 0,
-            title: "Print Options",
-            message: "What would you like to do?",
-        })
-        .then(({ response }) => {
-            if (response === 0) {
-                printAndSaveToPDF(mainWindow, htmlContent);
-            } else if (response === 1) {
-                printHTML(htmlContent);
+    const encodedLength = PRINT_DATA_URL_PREFIX.length + encodeURIComponent(previewContent).length;
+    const useFile = encodedLength > MAX_DATA_URL_LENGTH;
+
+    let tempPath: string | null = null;
+
+    if (useFile) {
+        tempPath = join(app.getPath("temp"), `print-preview-${Date.now().toString(36)}.html`);
+        writeFileSync(tempPath, previewContent, "utf-8");
+        previewWindow.loadFile(tempPath);
+    } else {
+        previewWindow.loadURL(`${PRINT_DATA_URL_PREFIX}${encodeURIComponent(previewContent)}`);
+    }
+
+    const cleanup = () => {
+        if (tempPath) {
+            try {
+                unlinkSync(tempPath);
+            } catch (_) {
+                // Ignore
             }
-        })
-        .catch((error) => {
-            printLogger.error("Print dialog error:", error);
-        });
+            tempPath = null;
+        }
+        if (isWindowValid(previewWindow)) previewWindow.close();
+    };
+
+    previewWindow.webContents.on("did-fail-load", (_, errorCode, errorDesc) => {
+        printLogger.error("Preview failed to load:", errorCode, errorDesc);
+        cleanup();
+    });
+
+    previewWindow.webContents.on("did-finish-load", () => {
+        // Attach the toolbar click handlers from the main process. Doing this
+        // via executeJavaScript (rather than inline onclick attributes in the
+        // injected toolbar HTML) means the handlers are not governed by the
+        // rendered email's Content-Security-Policy. Some messages ship a
+        // restrictive policy (e.g. script-src 'none') that would otherwise
+        // silently disable the buttons. Each click navigates to a sentinel
+        // URL, which the will-navigate handler below intercepts.
+        previewWindow.webContents
+            .executeJavaScript(
+                `document.querySelectorAll("#proton-print-toolbar button[data-action]").forEach(function (button) {
+                    button.addEventListener("click", function () {
+                        window.location.href = button.getAttribute("data-action");
+                    });
+                });
+                true;`
+            )
+            .catch((error) => {
+                printLogger.error("Failed to initialize preview toolbar:", error);
+            });
+
+        previewWindow.show();
+    });
+
+    previewWindow.webContents.on("will-navigate", (event, url) => {
+        event.preventDefault();
+
+        if (url === PREVIEW_ACTION_PRINT) {
+            printHTML(htmlContent).catch((error) => {
+                printLogger.error("Print error from preview:", error);
+            });
+        } else if (url === PREVIEW_ACTION_SAVE_PDF) {
+            const parent = isWindowValid(mainWindow) ? mainWindow : previewWindow;
+            printAndSaveToPDF(parent, htmlContent).catch((error) => {
+                printLogger.error("Save PDF error from preview:", error);
+            });
+        } else if (url === PREVIEW_ACTION_CLOSE) {
+            cleanup();
+        }
+    });
+
+    previewWindow.on("closed", () => {
+        if (tempPath) {
+            try {
+                unlinkSync(tempPath);
+            } catch (_) {
+                // Ignore
+            }
+        }
+    });
+}
+
+export function showPrintDialog(htmlContent: string) {
+    showPreviewWindow(htmlContent).catch((error) => {
+        printLogger.error("Print preview error:", error);
+    });
 }


### PR DESCRIPTION
…490)

## What this does

Adds a print preview to the Proton Mail desktop app, which currently has none — closes #490.

When you print an email in the desktop app today, `showPrintDialog()` shows a "Save as PDF / Print / Cancel" chooser and then prints via an invisible `BrowserWindow` (`show: false`), so you never see how the email will look. The web app has a working preview via `window.print()`; this brings the desktop app in line.

## How it works

- A visible `BrowserWindow` (800×900, titled "Print Preview") opens showing the email content with a small toolbar injected at the top: **Print**, **Save as PDF**, **Close**.
- The toolbar's click handlers are attached from the main process via `webContents.executeJavaScript()` (not inline `onclick`), so they are **not subject to the rendered email's Content-Security-Policy**. Some messages ship a restrictive policy (e.g. `script-src 'none'`) that would otherwise silently disable inline handlers. Each click navigates to a sentinel URL that a `will-navigate` listener intercepts and routes.
- The original HTML (without the toolbar) is what gets sent to the printer or PDF — the toolbar never appears in the output.

## Behavior change worth calling out

This **replaces the existing "Save as PDF / Print / Cancel" chooser dialog**. Those three actions are now buttons on the preview itself, so the user sees the email first and then chooses — rather than choosing blind. The existing `printHTML()` and `printAndSaveToPDF()` functions are unchanged; only the entry point (`showPrintDialog`) now opens the preview instead of the message box.

## Scope

Entirely self-contained in `applications/inbox-desktop/src/utils/printing/print.ts`. No new dependencies, no preload changes, no IPC changes, no backend or encryption surface.

## Testing

The runtime behavior was validated against **Electron 37.10.3** (the version this app ships) using a standalone harness, including an email carrying a strict CSP (`script-src 'none'`): the preview window opens, and the Print / Save as PDF / Close buttons all fire correctly under the CSP via the `executeJavaScript` wiring. An inline-`onclick` variant was confirmed to fail under that same CSP, which is why this PR uses `executeJavaScript`.

I was not able to build the full monorepo locally (the workspace graph and `nexus.protontech.ch` registry aren't available outside Proton's CI), so CI is the type-check and lint gate here. Happy to adjust anything the maintainers would like changed.