### PR TITLE
feat(pass-desktop): add optional screen privacy setting

### DIFF
--- a/applications/pass-desktop/CHANGELOG.md
+++ b/applications/pass-desktop/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- Add an optional Screen privacy setting on Windows and macOS, with capture limitations explained in Settings.
+
 ### Version 1.40.2
 
 - Fix being logged out during temporary server issues, keeping offline mode available

--- a/applications/pass-desktop/README.md
+++ b/applications/pass-desktop/README.md
@@ -45,6 +45,26 @@ On Linux, if you get a sandbox error, you'll need to disable Electron sandbox by
 ELECTRON_DISABLE_SANDBOX=1 yarn start
 ```
 
+## Screen privacy
+
+On Windows and macOS, **Settings > Security > Screen privacy** offers an optional setting to help prevent accidental exposure of the main Pass window in screenshots, screen recordings, and screen sharing. It is off by default, stored locally for this desktop installation, and reapplied before the main window is displayed. Changing it takes effect without restarting. `PASS_DEBUG` does not override the preference.
+
+This is not a guarantee against capture:
+
+- **Windows:** Electron uses `SetWindowDisplayAffinity`. Windows 10 version 2004 and later can exclude the window from capture; older versions capture a black window. Some capture tools may still capture its contents.
+- **macOS:** apps using ScreenCaptureKit can still capture the window even when protection is enabled. The setting displays this limitation explicitly.
+- **Linux:** Electron does not support this protection. The setting is hidden, and the main process rejects attempts to enable it.
+
+See [Electron's content protection documentation](https://www.electronjs.org/docs/latest/api/browser-window#winsetcontentprotectionenable-macos-windows).
+
+When validating a release, record the OS version and capture/sharing tools used:
+
+1. Enable and disable the setting; verify each change takes effect immediately.
+2. Enable it, quit the app completely, and relaunch; verify the preference and protection are restored. Also check hiding to the tray and reopening.
+3. Check screenshots, screen recordings, and both window and whole-screen sharing on Windows. On macOS, check and document the ScreenCaptureKit limitation.
+4. Confirm that Linux does not offer the setting.
+5. If reading the preference fails, the control must remain disabled with an unknown state and an error message. If an update fails, the last confirmed value must remain displayed and an error notification must appear.
+
 ## Internal only
 
 For Linux builds, you can add PassDesktop label on the MR and trigger the pipeline for linux builds

--- a/applications/pass-desktop/src/lib/content-protection.ts
+++ b/applications/pass-desktop/src/lib/content-protection.ts
@@ -1,0 +1,30 @@
+import type { BrowserWindow } from 'electron';
+
+import type { MaybeNull } from '@proton/pass/types';
+
+import { store } from '../store';
+import { setupIpcHandler } from './ipc';
+
+declare module 'proton-pass-desktop/lib/ipc' {
+    interface IPCChannels {
+        'contentProtection:get': IPCChannel<[], boolean>;
+        'contentProtection:set': IPCChannel<[enabled: boolean], void>;
+    }
+}
+
+export const getContentProtection = () => store.get('contentProtection') === true;
+
+export const applyContentProtection = (browserWindow: MaybeNull<BrowserWindow>, enabled = getContentProtection()) => {
+    browserWindow?.setContentProtection(Boolean(enabled && !process.env.PASS_DEBUG));
+};
+
+export const setContentProtection = (getWindow: () => MaybeNull<BrowserWindow>, enabled: boolean) => {
+    const value = enabled === true;
+    store.set('contentProtection', value);
+    applyContentProtection(getWindow(), value);
+};
+
+export const setupIpcHandlers = (getWindow: () => MaybeNull<BrowserWindow>) => {
+    setupIpcHandler('contentProtection:get', getContentProtection);
+    setupIpcHandler('contentProtection:set', (enabled) => setContentProtection(getWindow, enabled));
+};

--- a/applications/pass-desktop/src/lib/content-protection.ts
+++ b/applications/pass-desktop/src/lib/content-protection.ts
@@ -3,6 +3,7 @@ import type { BrowserWindow } from 'electron';
 import type { MaybeNull } from '@proton/pass/types';
 
 import { store } from '../store';
+import { isMac, isWindows } from '../utils/platform';
 import { setupIpcHandler } from './ipc';
 
 declare module 'proton-pass-desktop/lib/ipc' {
@@ -12,14 +13,17 @@ declare module 'proton-pass-desktop/lib/ipc' {
     }
 }
 
-export const getContentProtection = () => store.get('contentProtection') === true;
+const isSupported = () => isMac() || isWindows();
+
+export const getContentProtection = () => isSupported() && store.get('contentProtection') === true;
 
 export const applyContentProtection = (browserWindow: MaybeNull<BrowserWindow>, enabled = getContentProtection()) => {
-    browserWindow?.setContentProtection(Boolean(enabled && !process.env.PASS_DEBUG));
+    if (isSupported()) browserWindow?.setContentProtection(enabled);
 };
 
 export const setContentProtection = (getWindow: () => MaybeNull<BrowserWindow>, enabled: boolean) => {
     const value = enabled === true;
+    if (value && !isSupported()) throw new Error('Screen privacy is not supported on this platform');
     store.set('contentProtection', value);
     applyContentProtection(getWindow(), value);
 };

--- a/applications/pass-desktop/src/main.ts
+++ b/applications/pass-desktop/src/main.ts
@@ -20,6 +20,7 @@ import noop from '@proton/utils/noop';
 
 import config from './app/config';
 import { WINDOWS_APP_ID } from './constants';
+import { applyContentProtection } from './lib/content-protection';
 import { migrateSameSiteCookies, upgradeSameSiteCookies } from './lib/cookies';
 import { fixSSOUrl } from './lib/sso';
 import { getTheme } from './lib/theming';
@@ -156,6 +157,7 @@ const createWindow = async (session: Session): Promise<BrowserWindow> => {
 
     setApplicationMenu(ctx.window);
     registerWindowManagementHandlers(ctx.window);
+    applyContentProtection(ctx.window);
 
     ctx.window.on('show', () => {
         if (isMac()) void app.dock?.show();

--- a/applications/pass-desktop/src/preload.ts
+++ b/applications/pass-desktop/src/preload.ts
@@ -43,6 +43,10 @@ const contextBridgeApi: ContextBridgeApi = {
     getTheme: () => invoke('theming:getTheme'),
     setTheme: (theme) => invoke('theming:setTheme', theme),
 
+    /* content protection */
+    getContentProtection: () => invoke('contentProtection:get'),
+    setContentProtection: (enabled) => invoke('contentProtection:set', enabled),
+
     /* routing */
     navigate: (href) => invoke('router:navigate', href),
 

--- a/applications/pass-desktop/src/startup.ts
+++ b/applications/pass-desktop/src/startup.ts
@@ -2,6 +2,7 @@ import { setupIpcHandlers as autotype } from './lib/autotype';
 import biometrics from './lib/biometrics';
 import { setupIpcHandlers as client } from './lib/client';
 import { setupIpcHandlers as clipboard } from './lib/clipboard/clipboard.ipc';
+import { setupIpcHandlers as contentProtection } from './lib/content-protection';
 import contextMenu from './lib/context-menu';
 import { setupIpcHandlers as info } from './lib/install-info';
 import { nativeMessaging } from './lib/native-messaging/startup';
@@ -27,6 +28,7 @@ export const startup = async (app: Electron.App, ctx: PassElectronContext) => {
     sessionStorage(() => ctx.session);
     client();
     clipboard();
+    contentProtection(() => ctx.window);
     info();
     theming();
     autotype(() => ctx.window);

--- a/applications/pass-desktop/src/store.ts
+++ b/applications/pass-desktop/src/store.ts
@@ -8,6 +8,7 @@ import { calculateUpdateDistribution } from './lib/updater/helpers';
 import type { WindowConfigStoreProperties } from './lib/window-management';
 
 type RootStore = {
+    contentProtection?: boolean;
     installInfo?: StoreInstallProperties;
     update?: UpdateStore;
     theme?: DesktopTheme;

--- a/packages/pass/components/Settings/ContentProtection.spec.tsx
+++ b/packages/pass/components/Settings/ContentProtection.spec.tsx
@@ -1,0 +1,109 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import NotificationsChildren from '@proton/components/containers/notifications/Children';
+import NotificationsProvider from '@proton/components/containers/notifications/Provider';
+
+import { ContentProtection } from './ContentProtection';
+
+const renderSettings = () =>
+    render(
+        <NotificationsProvider>
+            <ContentProtection />
+            <NotificationsChildren />
+        </NotificationsProvider>
+    );
+
+describe('Screen privacy settings', () => {
+    const resizeObserverDescriptor = Object.getOwnPropertyDescriptor(window, 'ResizeObserver');
+    const desktopBuildDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'DESKTOP_BUILD');
+    const buildTargetDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'BUILD_TARGET');
+
+    beforeAll(() => {
+        Object.defineProperty(window, 'ResizeObserver', {
+            configurable: true,
+            value: class {
+                observe() {}
+                unobserve() {}
+                disconnect() {}
+            },
+        });
+    });
+
+    afterAll(() => {
+        if (resizeObserverDescriptor) Object.defineProperty(window, 'ResizeObserver', resizeObserverDescriptor);
+        else Reflect.deleteProperty(window, 'ResizeObserver');
+    });
+    const bridgeDescriptor = Object.getOwnPropertyDescriptor(window, 'ctxBridge');
+
+    beforeEach(() => {
+        Object.defineProperty(globalThis, 'DESKTOP_BUILD', { configurable: true, value: true });
+        Object.defineProperty(globalThis, 'BUILD_TARGET', { configurable: true, value: 'win32' });
+    });
+
+    afterEach(() => {
+        if (desktopBuildDescriptor) Object.defineProperty(globalThis, 'DESKTOP_BUILD', desktopBuildDescriptor);
+        else Reflect.deleteProperty(globalThis, 'DESKTOP_BUILD');
+        if (buildTargetDescriptor) Object.defineProperty(globalThis, 'BUILD_TARGET', buildTargetDescriptor);
+        else Reflect.deleteProperty(globalThis, 'BUILD_TARGET');
+        if (bridgeDescriptor) Object.defineProperty(window, 'ctxBridge', bridgeDescriptor);
+        else delete window.ctxBridge;
+    });
+
+    test('does not report protection as enabled until the desktop confirms the change', async () => {
+        let confirm!: () => void;
+        const pending = new Promise<void>((resolve) => {
+            confirm = resolve;
+        });
+        Object.defineProperty(window, 'ctxBridge', {
+            configurable: true,
+            value: { getContentProtection: async () => false, setContentProtection: () => pending },
+        });
+        renderSettings();
+        const checkbox = screen.getByRole('checkbox');
+        await waitFor(() => expect(checkbox).toBeEnabled());
+
+        fireEvent.click(checkbox);
+        expect(checkbox).toBeDisabled();
+        expect(checkbox).not.toBeChecked();
+
+        await act(async () => confirm());
+        expect(checkbox).toBeEnabled();
+        expect(checkbox).toBeChecked();
+    });
+
+    test('keeps the preference unavailable when its saved state cannot be read', async () => {
+        Object.defineProperty(window, 'ctxBridge', {
+            configurable: true,
+            value: {
+                getContentProtection: async () => {
+                    throw new Error('IPC unavailable');
+                },
+            },
+        });
+        renderSettings();
+
+        expect(await screen.findByRole('alert')).toBeVisible();
+        expect(screen.getByRole('checkbox')).toBeDisabled();
+        expect(screen.getByRole('checkbox')).toBePartiallyChecked();
+    });
+
+    test('keeps the confirmed preference and reports a rejected update', async () => {
+        Object.defineProperty(window, 'ctxBridge', {
+            configurable: true,
+            value: {
+                getContentProtection: async () => true,
+                setContentProtection: async () => {
+                    throw new Error('Cannot save setting');
+                },
+            },
+        });
+        renderSettings();
+        const checkbox = screen.getByRole('checkbox');
+        await waitFor(() => expect(checkbox).toBeEnabled());
+
+        fireEvent.click(checkbox);
+        expect(await screen.findByRole('alert')).toBeVisible();
+        expect(checkbox).toBeEnabled();
+        expect(checkbox).toBeChecked();
+    });
+});

--- a/packages/pass/components/Settings/ContentProtection.tsx
+++ b/packages/pass/components/Settings/ContentProtection.tsx
@@ -1,0 +1,69 @@
+import { type FC, useEffect, useState } from 'react';
+
+import { c } from 'ttag';
+
+import Checkbox from '@proton/components/components/input/Checkbox';
+import { PASS_APP_NAME } from '@proton/shared/lib/constants';
+import noop from '@proton/utils/noop';
+
+import { SettingsPanel } from './SettingsPanel';
+
+export const ContentProtection: FC = () => {
+    const [enabled, setEnabled] = useState(false);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const bridge = window.ctxBridge;
+        let active = true;
+
+        if (!bridge) {
+            setLoading(false);
+            return;
+        }
+
+        void bridge
+            .getContentProtection()
+            .then((value) => {
+                if (active) setEnabled(value);
+            })
+            .catch(noop)
+            .finally(() => {
+                if (active) setLoading(false);
+            });
+
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    const handleToggle = async () => {
+        const bridge = window.ctxBridge;
+        if (!bridge) return;
+
+        const nextEnabled = !enabled;
+        setEnabled(nextEnabled);
+        setLoading(true);
+
+        try {
+            await bridge.setContentProtection(nextEnabled);
+        } catch {
+            setEnabled(enabled);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <SettingsPanel title={c('Label').t`Screen privacy`}>
+            <Checkbox checked={enabled} disabled={loading} onChange={handleToggle} loading={loading}>
+                <span>
+                    {c('Label').t`Hide ${PASS_APP_NAME} from screen captures`}
+                    <span className="block color-weak text-sm">
+                        {c('Info')
+                            .t`When enabled, ${PASS_APP_NAME} hides its window from screenshots, screen recordings, and screen sharing when supported by your operating system.`}
+                    </span>
+                </span>
+            </Checkbox>
+        </SettingsPanel>
+    );
+};

--- a/packages/pass/components/Settings/ContentProtection.tsx
+++ b/packages/pass/components/Settings/ContentProtection.tsx
@@ -5,6 +5,7 @@ import { c } from 'ttag';
 import { useNotifications } from '@proton/app-context/useNotifications';
 import { Banner } from '@proton/atoms/Banner/Banner';
 import Checkbox from '@proton/components/components/input/Checkbox';
+import { IcExclamationTriangleFilled } from '@proton/icons/icons/IcExclamationTriangleFilled';
 import { PASS_APP_NAME } from '@proton/shared/lib/constants';
 
 import { SettingsPanel } from './SettingsPanel';
@@ -82,9 +83,17 @@ const ContentProtectionDesktop: FC = () => {
                     .t`Helps prevent accidental exposure of the ${PASS_APP_NAME} window in screenshots, screen recordings, and screen sharing. Some capture tools may still capture its contents.`}
             </p>
             {BUILD_TARGET === 'darwin' && (
-                <Banner variant="warning" className="mt-3">
-                    {c('Warning')
-                        .t`On macOS, apps using ScreenCaptureKit can still capture this window, even when screen privacy is enabled.`}
+                <Banner
+                    variant="warning"
+                    className="mt-3"
+                    noIcon
+                    contentWrapperClassName="flex flex-nowrap items-center gap-2"
+                >
+                    <IcExclamationTriangleFilled className="shrink-0" color="var(--banner-accent-color)" />
+                    <span>
+                        {c('Warning')
+                            .t`On macOS, apps using ScreenCaptureKit can still capture this window, even when screen privacy is enabled.`}
+                    </span>
                 </Banner>
             )}
         </SettingsPanel>

--- a/packages/pass/components/Settings/ContentProtection.tsx
+++ b/packages/pass/components/Settings/ContentProtection.tsx
@@ -2,14 +2,16 @@ import { type FC, useEffect, useState } from 'react';
 
 import { c } from 'ttag';
 
+import { useNotifications } from '@proton/app-context/useNotifications';
+import { Banner } from '@proton/atoms/Banner/Banner';
 import Checkbox from '@proton/components/components/input/Checkbox';
 import { PASS_APP_NAME } from '@proton/shared/lib/constants';
-import noop from '@proton/utils/noop';
 
 import { SettingsPanel } from './SettingsPanel';
 
-export const ContentProtection: FC = () => {
-    const [enabled, setEnabled] = useState(false);
+const ContentProtectionDesktop: FC = () => {
+    const { createNotification } = useNotifications();
+    const [enabled, setEnabled] = useState<boolean>();
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
@@ -26,7 +28,9 @@ export const ContentProtection: FC = () => {
             .then((value) => {
                 if (active) setEnabled(value);
             })
-            .catch(noop)
+            .catch(() => {
+                if (active) setEnabled(undefined);
+            })
             .finally(() => {
                 if (active) setLoading(false);
             });
@@ -38,16 +42,19 @@ export const ContentProtection: FC = () => {
 
     const handleToggle = async () => {
         const bridge = window.ctxBridge;
-        if (!bridge) return;
+        if (!bridge || enabled === undefined || loading) return;
 
         const nextEnabled = !enabled;
-        setEnabled(nextEnabled);
         setLoading(true);
 
         try {
             await bridge.setContentProtection(nextEnabled);
+            setEnabled(nextEnabled);
         } catch {
-            setEnabled(enabled);
+            createNotification({
+                type: 'error',
+                text: c('Error').t`Unable to update screen privacy. Please try again.`,
+            });
         } finally {
             setLoading(false);
         }
@@ -55,15 +62,36 @@ export const ContentProtection: FC = () => {
 
     return (
         <SettingsPanel title={c('Label').t`Screen privacy`}>
-            <Checkbox checked={enabled} disabled={loading} onChange={handleToggle} loading={loading}>
-                <span>
-                    {c('Label').t`Hide ${PASS_APP_NAME} from screen captures`}
-                    <span className="block color-weak text-sm">
-                        {c('Info')
-                            .t`When enabled, ${PASS_APP_NAME} hides its window from screenshots, screen recordings, and screen sharing when supported by your operating system.`}
-                    </span>
-                </span>
+            {!loading && enabled === undefined && (
+                <Banner variant="danger" role="alert" className="mb-3">
+                    {c('Error').t`Unable to load screen privacy. Reopen Settings to try again.`}
+                </Banner>
+            )}
+            <Checkbox
+                checked={enabled === true}
+                indeterminate={enabled === undefined}
+                disabled={loading || enabled === undefined}
+                onChange={handleToggle}
+                loading={loading}
+                aria-describedby="content-protection-description"
+            >
+                {c('Label').t`Hide ${PASS_APP_NAME} from screen captures`}
             </Checkbox>
+            <p id="content-protection-description" className="color-weak text-sm mt-2 mb-0">
+                {c('Info')
+                    .t`Helps prevent accidental exposure of the ${PASS_APP_NAME} window in screenshots, screen recordings, and screen sharing. Some capture tools may still capture its contents.`}
+            </p>
+            {BUILD_TARGET === 'darwin' && (
+                <Banner variant="warning" className="mt-3">
+                    {c('Warning')
+                        .t`On macOS, apps using ScreenCaptureKit can still capture this window, even when screen privacy is enabled.`}
+                </Banner>
+            )}
         </SettingsPanel>
     );
+};
+
+export const ContentProtection: FC = () => {
+    if (!DESKTOP_BUILD || (BUILD_TARGET !== 'win32' && BUILD_TARGET !== 'darwin')) return null;
+    return <ContentProtectionDesktop />;
 };

--- a/packages/pass/components/Settings/ContentProtection.tsx
+++ b/packages/pass/components/Settings/ContentProtection.tsx
@@ -74,14 +74,19 @@ const ContentProtectionDesktop: FC = () => {
                 disabled={loading || enabled === undefined}
                 onChange={handleToggle}
                 loading={loading}
+                aria-labelledby="content-protection-label"
                 aria-describedby="content-protection-description"
             >
-                {c('Label').t`Hide ${PASS_APP_NAME} from screen captures`}
+                <span>
+                    <span id="content-protection-label">
+                        {c('Label').t`Hide ${PASS_APP_NAME} from screen captures`}
+                    </span>
+                    <span id="content-protection-description" className="block color-weak text-sm">
+                        {c('Info')
+                            .t`Helps prevent accidental exposure of the ${PASS_APP_NAME} window in screenshots, screen recordings, and screen sharing. Some capture tools may still capture its contents.`}
+                    </span>
+                </span>
             </Checkbox>
-            <p id="content-protection-description" className="color-weak text-sm mt-2 mb-0">
-                {c('Info')
-                    .t`Helps prevent accidental exposure of the ${PASS_APP_NAME} window in screenshots, screen recordings, and screen sharing. Some capture tools may still capture its contents.`}
-            </p>
             {BUILD_TARGET === 'darwin' && (
                 <Banner
                     variant="warning"

--- a/packages/pass/components/Settings/Views/Tabs/Security.tsx
+++ b/packages/pass/components/Settings/Views/Tabs/Security.tsx
@@ -1,11 +1,12 @@
 import type { FC } from 'react';
 
 import { Clipboard } from '../../Clipboard';
+import { ContentProtection } from '../../ContentProtection';
 import { ExtraPassword } from '../../ExtraPassword';
 import { LockSettings } from '../../LockSettings';
 
 export const Security: FC = () => [
     <LockSettings key="lock" />,
     <ExtraPassword key="extra-pwd" />,
-    ...(DESKTOP_BUILD ? [<Clipboard key="clipboard" />] : []),
+    ...(DESKTOP_BUILD ? [<Clipboard key="clipboard" />, <ContentProtection key="content-protection" />] : []),
 ];

--- a/packages/pass/types/desktop/index.ts
+++ b/packages/pass/types/desktop/index.ts
@@ -42,6 +42,9 @@ export type ContextBridgeApi = {
     getTheme: () => Promise<Maybe<DesktopTheme>>;
     setTheme: (theme: DesktopTheme) => Promise<void>;
 
+    getContentProtection: () => Promise<boolean>;
+    setContentProtection: (enabled: boolean) => Promise<void>;
+
     autotype: ({ fields, enterAtTheEnd }: AutotypeProperties) => Promise<void>;
 
     openContextMenu: (items: ContextMenuItemSerializable[]) => Promise<number>;


### PR DESCRIPTION
## Context

Makes screen privacy optional rather than always enabled, following the feedback on #512. Users can opt in to reduce accidental exposure of the Proton Pass desktop window during screen capture or sharing.

## Changes

- Adds **Screen privacy** under **Settings > Security** on Windows and macOS, disabled by default.
- Persists the preference and exposes typed read/write operations through the desktop context bridge.
- Applies the saved preference before the main window is shown and updates the current window when the setting changes, including in development builds.
- Keeps the checkbox unavailable when the saved preference cannot be read. A rejected update preserves the last confirmed state and shows an error notification.
- Hides the setting on unsupported platforms and guards native content-protection calls.
- Adds explanatory copy and a macOS warning. The checkbox layout follows the existing Extra password setting, and the warning icon is vertically centered beside multiline text.
- Documents platform limitations and a manual verification checklist in the desktop README; adds a changelog entry.

## Platform limitations

This is a best-effort OS feature, not a guarantee against all capture tools.

- **Windows:** uses Electron's native window content protection. Behavior depends on the Windows version and capture mechanism.
- **macOS:** applications using ScreenCaptureKit may still capture the window despite content protection. The UI explicitly warns about this limitation.
- **Linux:** the setting is not exposed and native content-protection calls are not made.

## Validation

- Desktop and shared Pass TypeScript checks passed.
- Targeted ESLint checks on changed files and shared i18n validation passed.
- Three settings regression tests passed: delayed confirmation, unavailable saved state, and rejected updates.
- Seven existing macOS updater error tests passed.
- Launched the actual macOS desktop application with an isolated profile. Verified the real settings component and styles at normal and narrow viewport widths, including label/description alignment, warning-icon centering, accessible naming, and clicks on the label and description.
- Native Electron smoke checks on macOS covered preference persistence across a full process restart, window hide/show and recreation, and application of protection in development mode.
- **Windows VM, build 26100, Electron 39.8.10 x64:** exercised the PR's actual content-protection module, preload, and IPC with synthetic window content. Desktop capture included the window with protection off, excluded it with protection on, and included it again after disabling protection. The window remained visible and non-minimized throughout. This was a targeted native integration check, not a full packaged Windows application test or validation of every capture tool.
- Linux guards were exercised through simulated platform/build branches; no native Linux run was performed.
