### PR TITLE
feat(mail): create Calendar events from email

### DIFF
--- a/applications/calendar/src/app/components/calendar/DayGrid.tsx
+++ b/applications/calendar/src/app/components/calendar/DayGrid.tsx
@@ -8,6 +8,7 @@ import chunk from '@proton/utils/chunk';
 
 import type { CalendarViewEvent, TargetEventData, TargetMoreData } from '../../containers/calendar/interface';
 import { useRect } from '../../hooks/useRect';
+import useCalendarMailDrop from '../../hooks/useCalendarMailDrop';
 import DayButtons from './DayGrid/DayButtons';
 import RowEvents from './DayGrid/RowEvents';
 import { DAY_EVENT_HEIGHT } from './constants';
@@ -68,6 +69,8 @@ const DayGrid = ({
         return chunk(eachDayOfInterval(start, end), daysInWeek);
         // eslint-disable-next-line react-hooks/exhaustive-deps -- autofix-eslint-305117
     }, [+start, +end]);
+
+    const { handleMailDropOnDayGrid, handleMailDragOver } = useCalendarMailDrop();
 
     const eventsPerRows = useDayGridEventLayout(rows, events, numberOfRows, dayEventHeight);
 
@@ -184,7 +187,17 @@ const DayGrid = ({
                         </div>
                     ) : null}
 
-                    <div className="flex flex-1 flex-column calendar-daygrid-rows" ref={rowsWrapperRef}>
+                    <div
+                        className="flex flex-1 flex-column calendar-daygrid-rows"
+                        ref={rowsWrapperRef}
+                        onDragOver={handleMailDragOver}
+                        onDrop={(event) =>
+                            handleMailDropOnDayGrid(event, {
+                                rows,
+                                dayGridEl: rowsWrapperRef.current!,
+                            })
+                        }
+                    >
                         {rows.map((days, rowIndex) => {
                             const { eventsInRow, eventsInRowStyles, eventsInRowSummary } = eventsPerRows[rowIndex];
 

--- a/applications/calendar/src/app/components/calendar/TimeGrid.tsx
+++ b/applications/calendar/src/app/components/calendar/TimeGrid.tsx
@@ -19,6 +19,7 @@ import clsx from '@proton/utils/clsx';
 
 import { useBookings } from '../../containers/bookings/bookingsProvider/BookingsProvider';
 import { isBookingSlotEvent } from '../../containers/bookings/utils/calendar/calendarHelper';
+import useCalendarMailDrop from '../../hooks/useCalendarMailDrop';
 import type {
     CalendarViewBusyEvent,
     CalendarViewEvent,
@@ -120,6 +121,8 @@ const TimeGrid = ({
     const titleRef = useRef<HTMLDivElement>(null);
     const scrollRef = useRef<HTMLDivElement>(null);
     const partDayEventViewRef = useRef<HTMLDivElement>(null);
+
+    const { handleMailDrop, handleMailDragOver } = useCalendarMailDrop();
 
     const { viewportWidth } = useActiveBreakpoint();
 
@@ -479,7 +482,17 @@ const TimeGrid = ({
                             />
                         ) : null}
                         <HourTexts className="calendar-aside calendar-primary-timezone-cell" hours={formattedHours} />
-                        <div className="flex flex-1 relative calendar-grid-gridcells" ref={timeGridRef}>
+                        <div
+                            className="flex flex-1 relative calendar-grid-gridcells"
+                            ref={timeGridRef}
+                            onDragOver={handleMailDragOver}
+                            onDrop={(event) =>
+                                handleMailDrop(event, {
+                                    days: viewportWidth['<=small'] ? [date] : days,
+                                    timeGridEl: timeGridRef.current!,
+                                })
+                            }
+                        >
                             <HourLines hours={hours} />
                             {days.map((day, dayIndex) => {
                                 const key = getKey(day);

--- a/applications/calendar/src/app/components/calendar/mouseHelpers/dateHelpers.spec.ts
+++ b/applications/calendar/src/app/components/calendar/mouseHelpers/dateHelpers.spec.ts
@@ -1,0 +1,131 @@
+import { getMailDropDayStart, getMailDropStart } from './dateHelpers';
+
+describe('getMailDropStart', () => {
+    // Tuesday, 1 September 2026, represented as a fake-UTC date.
+    const tuesday = new Date(Date.UTC(2026, 8, 1));
+
+    const oneDayGrid = (gridY: number) => ({
+        clientX: 0,
+        clientY: gridY,
+        gridRect: { left: 0, top: 0, width: 600, height: 1440 },
+        days: [tuesday],
+        interval: 30,
+    });
+
+    it('maps a drop at 14:00 on a single day to Tuesday 14:00', () => {
+        // 14:00 -> 840 minutes into a 1440-minute (24h) grid.
+        const start = getMailDropStart(oneDayGrid(840));
+
+        expect(start).toEqual(Date.UTC(2026, 8, 1, 14, 0));
+    });
+
+    it('snaps off-grid drop positions to the configured interval', () => {
+        // 9:07 -> snaps down to 9:00 (540 minutes).
+        const start = getMailDropStart(oneDayGrid(547));
+
+        expect(start).toEqual(Date.UTC(2026, 8, 1, 9, 0));
+    });
+
+    it('clamps a drop beyond the right edge to the nearest day column', () => {
+        const start = getMailDropStart({
+            ...oneDayGrid(840),
+            // clientX far beyond the single-day column width
+            clientX: 5000,
+        });
+
+        expect(start).toEqual(Date.UTC(2026, 8, 1, 14, 0));
+    });
+
+    it('returns 0 when there are no day columns', () => {
+        const start = getMailDropStart({
+            ...oneDayGrid(840),
+            days: [],
+        });
+
+        expect(start).toEqual(0);
+    });
+
+    describe('week view', () => {
+        const sunday = new Date(Date.UTC(2026, 7, 30));
+        const monday = new Date(Date.UTC(2026, 7, 31));
+        const tuesday = new Date(Date.UTC(2026, 8, 1));
+        const week = [sunday, monday, tuesday];
+
+        it('maps a drop onto the third day (Tuesday) at 14:00', () => {
+            // 7-day week split into 3 equal columns -> Tuesday occupies x in [400, 600).
+            const start = getMailDropStart({
+                clientX: 500,
+                clientY: 840,
+                gridRect: { left: 0, top: 0, width: 600, height: 1440 },
+                days: week,
+                interval: 30,
+            });
+
+            expect(start).toEqual(Date.UTC(2026, 8, 1, 14, 0));
+        });
+
+        it('maps a drop onto the first day (Sunday) at 09:00', () => {
+            const start = getMailDropStart({
+                clientX: 100,
+                clientY: 540,
+                gridRect: { left: 0, top: 0, width: 600, height: 1440 },
+                days: week,
+                interval: 30,
+            });
+
+            expect(start).toEqual(Date.UTC(2026, 7, 30, 9, 0));
+        });
+    });
+});
+
+describe('getMailDropDayStart', () => {
+    // A 2-row month grid: 7 columns per row.
+    const row0 = [
+        new Date(Date.UTC(2026, 7, 30)),
+        new Date(Date.UTC(2026, 7, 31)),
+        new Date(Date.UTC(2026, 8, 1)),
+        new Date(Date.UTC(2026, 8, 2)),
+        new Date(Date.UTC(2026, 8, 3)),
+        new Date(Date.UTC(2026, 8, 4)),
+        new Date(Date.UTC(2026, 8, 5)),
+    ];
+    const row1 = [
+        new Date(Date.UTC(2026, 8, 6)),
+        new Date(Date.UTC(2026, 8, 7)),
+        new Date(Date.UTC(2026, 8, 8)),
+        new Date(Date.UTC(2026, 8, 9)),
+        new Date(Date.UTC(2026, 8, 10)),
+        new Date(Date.UTC(2026, 8, 11)),
+        new Date(Date.UTC(2026, 8, 12)),
+    ];
+
+    it('maps a drop onto a day cell to the start of that day (default time)', () => {
+        // row 0, column 2 (Tuesday 1 Sep): x in [171, 257), y in first half.
+        const start = getMailDropDayStart({
+            clientX: 200,
+            clientY: 50,
+            gridRect: { left: 0, top: 0, width: 600, height: 200 },
+            rows: [row0, row1],
+        });
+
+        expect(start).toEqual(Date.UTC(2026, 8, 1));
+    });
+
+    it('maps a drop onto the second row to that row day', () => {
+        const start = getMailDropDayStart({
+            clientX: 500,
+            clientY: 150,
+            gridRect: { left: 0, top: 0, width: 600, height: 200 },
+            rows: [row0, row1],
+        });
+
+        // row 1, column 5 (Friday 11 Sep)
+        expect(start).toEqual(Date.UTC(2026, 8, 11));
+    });
+
+    it('returns 0 when there are no rows', () => {
+        expect(getMailDropDayStart({ clientX: 0, clientY: 0, gridRect: { left: 0, top: 0, width: 600, height: 200 }, rows: [] })).toEqual(
+            0
+        );
+    });
+});

--- a/applications/calendar/src/app/components/calendar/mouseHelpers/dateHelpers.ts
+++ b/applications/calendar/src/app/components/calendar/mouseHelpers/dateHelpers.ts
@@ -1,6 +1,6 @@
 import { addDays, addMinutes, startOfDay } from '@proton/shared/lib/date-fns-utc';
 
-import { getRelativePosition } from './mathHelpers';
+import { getRelativePosition, getTargetIndex } from './mathHelpers';
 
 const getSnappedMinutes = (minutes: number, interval: number) => {
     return Math.floor((minutes / 60) * (60 / interval)) * interval;
@@ -33,4 +33,72 @@ export const getNewTime = (date: Date, minutes: number) => {
     const result = startOfDay(date);
     result.setUTCMinutes(minutes);
     return result;
+};
+
+/**
+ * Compute the start timestamp of the slot the mouse position points to, reusing
+ * the same slot-position logic as the interactive time grid. Used by the
+ * "create calendar event from mail" drop target.
+ */
+export const getMailDropStart = ({
+    clientX,
+    clientY,
+    gridRect,
+    days,
+    interval,
+}: {
+    clientX: number;
+    clientY: number;
+    gridRect: { left: number; top: number; width: number; height: number };
+    days: Date[];
+    interval: number;
+}): number => {
+    const totalMinutes = 24 * 60;
+    const targetDate = getTargetIndex(clientX, gridRect.left, gridRect.width, days.length);
+    const day = days[targetDate];
+
+    if (!day) {
+        return 0;
+    }
+
+    const targetMinutes = getTargetMinutes(clientY, gridRect.top, gridRect.height, totalMinutes, interval);
+
+    return getNewTime(day, targetMinutes).getTime();
+};
+
+/**
+ * Compute the start timestamp of the slot the mouse position points to on the
+ * month (day) grid. Month cells have no time axis, so a drop maps to the start
+ * of the target day (00:00) and the event uses Calendar's default duration.
+ */
+export const getMailDropDayStart = ({
+    clientX,
+    clientY,
+    gridRect,
+    rows,
+}: {
+    clientX: number;
+    clientY: number;
+    gridRect: { left: number; top: number; width: number; height: number };
+    rows: Date[][];
+}): number => {
+    const totalRows = rows.length;
+    if (!totalRows) {
+        return 0;
+    }
+
+    const targetRow = getTargetIndex(clientY, gridRect.top, gridRect.height, totalRows);
+    const days = rows[targetRow];
+    if (!days?.length) {
+        return 0;
+    }
+
+    const targetDay = getTargetIndex(clientX, gridRect.left, gridRect.width, days.length);
+    const day = days[targetDay];
+
+    if (!day) {
+        return 0;
+    }
+
+    return getNewTime(day, 0).getTime();
 };

--- a/applications/calendar/src/app/containers/calendar/InteractiveCalendarView.tsx
+++ b/applications/calendar/src/app/containers/calendar/InteractiveCalendarView.tsx
@@ -469,6 +469,7 @@ const InteractiveCalendarView = ({
         onChangeDate,
         tzid,
         setEventTargetAction,
+        onCreateEventFromMail: (payload) => interactiveRef.current?.createEventFromMail(payload),
     });
 
     useEffect(
@@ -2209,6 +2210,40 @@ const InteractiveCalendarView = ({
                 attendees,
                 title,
                 location,
+                description,
+            });
+        },
+        createEventFromMail: ({ subject, sender, start }) => {
+            // Minimal Mail reference for the event description. No body or
+            // content is ever copied into the event.
+            const description = sender ? c('Email').t`From: ${sender}` : undefined;
+
+            // No explicit start (menu action "Add to Calendar"): open the editor
+            // with the subject prefilled and Calendar's default date/time.
+            if (!start) {
+                handleCreateEvent({ title: subject, description });
+                return;
+            }
+
+            const baseModel = getCreateModel(false);
+            if (!baseModel) {
+                return;
+            }
+
+            // `start` is the number timestamp of a fake-UTC Date for the dropped
+            // slot, as produced by the time grid's slot-position logic in Mail.
+            // `end` is `start` + the calendar's default event duration.
+            const startDate = new Date(start);
+            const startModel = getUpdatedDateTime(baseModel, {
+                isAllDay: false,
+                start: startDate,
+                end: new Date(startDate.getTime() + baseModel.defaultEventDuration * 60000),
+                tzid,
+            });
+
+            handleCreateEvent({
+                startModel,
+                title: subject,
                 description,
             });
         },

--- a/applications/calendar/src/app/containers/calendar/interface.ts
+++ b/applications/calendar/src/app/containers/calendar/interface.ts
@@ -64,6 +64,7 @@ export interface TimeGridRef {
 
 export interface InteractiveRef {
     createEvent: (attendees: AttendeeModel[], title?: string, location?: string, description?: string) => void;
+    createEventFromMail: (payload: { subject: string; sender?: string; start?: number }) => void;
 }
 
 export interface CalendarViewEventTemporaryEvent extends CalendarViewEvent {

--- a/applications/calendar/src/app/hooks/useCalendarMailDrop.ts
+++ b/applications/calendar/src/app/hooks/useCalendarMailDrop.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import type { DragEvent as ReactDragEvent } from 'react';
+
+import { APPS } from '@proton/shared/lib/constants';
+import { getIsDrawerPostMessage, postMessageFromIframe } from '@proton/shared/lib/drawer/helpers';
+import { DRAWER_EVENTS } from '@proton/shared/lib/drawer/interfaces';
+
+import { getMailDropDayStart, getMailDropStart } from '../../components/calendar/mouseHelpers/dateHelpers';
+
+const interval = 30;
+
+/**
+ * Calendar-side counterpart to Mail's single-message drag. Tracks the generic
+ * `CALENDAR_MAIL_DRAG_STATE` signal sent by Mail while an email is dragged,
+ * exposes whether the day/week grid is currently a valid drop target, and, on
+ * drop, computes the target slot using the grid's existing slot-position logic
+ * and reports it back to Mail via `CALENDAR_MAIL_DROP`.
+ */
+const useCalendarMailDrop = () => {
+    const mailDragActiveRef = useRef(false);
+
+    useEffect(() => {
+        const handleMessage = (event: MessageEvent) => {
+            if (!getIsDrawerPostMessage(event)) {
+                return;
+            }
+
+            if (event.data.type !== DRAWER_EVENTS.CALENDAR_MAIL_DRAG_STATE) {
+                return;
+            }
+
+            const { active } = event.data.payload;
+            mailDragActiveRef.current = active;
+        };
+
+        window.addEventListener('message', handleMessage);
+
+        return () => {
+            window.removeEventListener('message', handleMessage);
+        };
+    }, []);
+
+    const handleMailDrop = useCallback(
+        (event: ReactDragEvent, { days, timeGridEl }: { days: Date[]; timeGridEl: HTMLElement }) => {
+            if (!mailDragActiveRef.current) {
+                return;
+            }
+
+            const gridRect = timeGridEl.getBoundingClientRect();
+            const start = getMailDropStart({
+                clientX: event.clientX,
+                clientY: event.clientY,
+                gridRect,
+                days,
+                interval,
+            });
+
+            if (!start) {
+                return;
+            }
+
+            postMessageFromIframe(
+                {
+                    type: DRAWER_EVENTS.CALENDAR_MAIL_DROP,
+                    payload: { start },
+                },
+                APPS.PROTONMAIL
+            );
+        },
+        []
+    );
+
+    const handleMailDropOnDayGrid = useCallback(
+        (event: ReactDragEvent, { rows, dayGridEl }: { rows: Date[][]; dayGridEl: HTMLElement }) => {
+            if (!mailDragActiveRef.current) {
+                return;
+            }
+
+            const gridRect = dayGridEl.getBoundingClientRect();
+            const start = getMailDropDayStart({
+                clientX: event.clientX,
+                clientY: event.clientY,
+                gridRect,
+                rows,
+            });
+
+            if (!start) {
+                return;
+            }
+
+            postMessageFromIframe(
+                {
+                    type: DRAWER_EVENTS.CALENDAR_MAIL_DROP,
+                    payload: { start },
+                },
+                APPS.PROTONMAIL
+            );
+        },
+        []
+    );
+
+    const handleMailDragOver = useCallback((event: ReactDragEvent) => {
+        if (!mailDragActiveRef.current) {
+            return;
+        }
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+    }, []);
+
+    return { handleMailDrop, handleMailDropOnDayGrid, handleMailDragOver };
+};
+
+export default useCalendarMailDrop;

--- a/applications/calendar/src/app/hooks/useOpenEventsFromMail.tsx
+++ b/applications/calendar/src/app/hooks/useOpenEventsFromMail.tsx
@@ -20,9 +20,22 @@ interface Props {
     onChangeDate: (newDate: Date) => void;
     tzid: string;
     setEventTargetAction: Dispatch<SetStateAction<EventTargetAction | undefined>>;
+    onCreateEventFromMail?: (payload: {
+        messageID: string;
+        subject: string;
+        sender?: string;
+        start?: number;
+    }) => void;
 }
 
-export const useOpenEventsFromMail = ({ calendars, addresses, onChangeDate, tzid, setEventTargetAction }: Props) => {
+export const useOpenEventsFromMail = ({
+    calendars,
+    addresses,
+    onChangeDate,
+    tzid,
+    setEventTargetAction,
+    onCreateEventFromMail,
+}: Props) => {
     const { call } = useCalendarModelEventManager();
     const { createNotification } = useNotifications();
     const openEvent = useOpenEvent();
@@ -69,6 +82,12 @@ export const useOpenEventsFromMail = ({ calendars, addresses, onChangeDate, tzid
                         void call([event.data.payload.calendarID]);
                     }
                     break;
+                case DRAWER_EVENTS.CALENDAR_CREATE_EVENT_FROM_MAIL:
+                    {
+                        const { messageID, subject, sender, start } = event.data.payload;
+                        onCreateEventFromMail?.({ messageID, subject, sender, start });
+                    }
+                    break;
                 case DRAWER_EVENTS.SHOW:
                     {
                         // When showing again the cached calendar app, we need to call the event manager for all calendars to get all updates
@@ -81,7 +100,7 @@ export const useOpenEventsFromMail = ({ calendars, addresses, onChangeDate, tzid
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps -- autofix-eslint-F64852
-        [calendars, addresses, goToEvent, goToOccurrence]
+        [calendars, addresses, goToEvent, goToOccurrence, onCreateEventFromMail]
     );
 
     useEffect(() => {

--- a/applications/mail/src/app/components/message/extrasHeader/HeaderMoreDropdown.tsx
+++ b/applications/mail/src/app/components/message/extrasHeader/HeaderMoreDropdown.tsx
@@ -21,6 +21,7 @@ import { FeatureCode, useFeature } from '@proton/features';
 import { useLoading } from '@proton/hooks';
 import { IcArchiveBox } from '@proton/icons/icons/IcArchiveBox';
 import { IcArrowUpFromSquare } from '@proton/icons/icons/IcArrowUpFromSquare';
+import { IcCalendarGrid } from '@proton/icons/icons/IcCalendarGrid';
 import { IcCode } from '@proton/icons/icons/IcCode';
 import { IcCrossCircle } from '@proton/icons/icons/IcCrossCircle';
 import { IcEnvelopeDot } from '@proton/icons/icons/IcEnvelopeDot';
@@ -49,8 +50,13 @@ import type {
     MessageStateWithData,
     MessageWithOptionalBody,
 } from '@proton/mail/store/messages/messagesTypes';
+import {
+    TelemetryMailCalendarCreateEventEvents,
+    TelemetryMeasurementGroups,
+} from '@proton/shared/lib/api/telemetry';
 import { MAILBOX_LABEL_IDS } from '@proton/shared/lib/constants';
 import downloadFile from '@proton/shared/lib/helpers/downloadFile';
+import { sendTelemetryReport } from '@proton/shared/lib/helpers/metrics';
 import type { MailSettings } from '@proton/shared/lib/interfaces';
 import type { Message } from '@proton/shared/lib/interfaces/mail/Message';
 import { CUSTOM_VIEWS, CUSTOM_VIEWS_LABELS, MARK_AS_STATUS } from '@proton/shared/lib/mail/constants';
@@ -67,6 +73,8 @@ import { APPLY_LOCATION_TYPES } from '../../../hooks/actions/applyLocation/inter
 import { useApplyLocation } from '../../../hooks/actions/applyLocation/useApplyLocation';
 import { useMarkAs } from '../../../hooks/actions/markAs/useMarkAs';
 import { useGetAttachment } from '../../../hooks/attachments/useAttachment';
+import { getSenderFromMessage } from '../../../helpers/calendar/createEventFromMessage';
+import useCreateCalendarEventFromMessage from '../../../hooks/drawer/useCreateCalendarEventFromMessage';
 import { useGetMessageKeys } from '../../../hooks/message/useGetMessageKeys';
 import type { Element } from '../../../models/element';
 import { updateAttachment } from '../../../store/attachments/attachmentsActions';
@@ -146,6 +154,7 @@ const HeaderMoreDropdown = ({
     const [messagePhishingModalProps, setMessagePhishingModalOpen, renderMessagePhishingModal] = useModalState();
     const [messagePermanentDeleteModalProps, setMessagePermanentDeleteModalOpen, renderMessagePermanentDeleteModal] =
         useModalState();
+    const createCalendarEventFromMessage = useCreateCalendarEventFromMessage();
     const canExpire = canSetExpiration(feature?.Value, user, message);
     const isStarred = IsMessageStarred(message.data || ({} as Element));
     const messageID = message.data?.ID || '';
@@ -218,6 +227,24 @@ const HeaderMoreDropdown = ({
                 showSuccessNotification: false,
             })
         );
+    };
+
+    const handleAddToCalendar = () => {
+        closeDropdown.current?.();
+
+        createCalendarEventFromMessage({
+            messageID,
+            subject: message.data?.Subject || '',
+            sender: getSenderFromMessage(message.data),
+        });
+
+        void sendTelemetryReport({
+            api,
+            measurementGroup: TelemetryMeasurementGroups.mailCalendarCreateEvent,
+            event: TelemetryMailCalendarCreateEventEvents.create_event,
+            silence: true,
+            dimensions: { entry_point: 'menu_action' },
+        });
     };
 
     const handleExpire = (days: number) => {
@@ -509,6 +536,15 @@ const HeaderMoreDropdown = ({
                                     >
                                         {isStarred ? <IcStarSlash className="mr-2" /> : <IcStar className="mr-2" />}
                                         <span className="flex-1 my-auto">{staringText}</span>
+                                    </DropdownMenuButton>
+
+                                    <DropdownMenuButton
+                                        className="text-left flex flex-nowrap items-center"
+                                        onClick={handleAddToCalendar}
+                                        data-testid="message-view-more-dropdown:add-to-calendar"
+                                    >
+                                        <IcCalendarGrid className="mr-2" />
+                                        <span className="flex-1 my-auto">{c('Action').t`Add to Calendar`}</span>
                                     </DropdownMenuButton>
 
                                     <hr className="my-2" />

--- a/applications/mail/src/app/helpers/calendar/createEventFromMessage.test.ts
+++ b/applications/mail/src/app/helpers/calendar/createEventFromMessage.test.ts
@@ -1,0 +1,61 @@
+import type { Message } from '@proton/shared/lib/interfaces/mail/Message';
+
+import { getCreateEventFromMessagePayload, getSenderFromMessage } from './createEventFromMessage';
+
+const buildMessage = (overrides: Partial<Message> = {}) =>
+    ({
+        ID: 'message-123',
+        Subject: 'Project review',
+        Sender: { Address: 'jane@example.com', Name: 'Jane Smith' },
+        ...overrides,
+    }) as Message;
+
+describe('createEventFromMessage', () => {
+    describe('getSenderFromMessage', () => {
+        it('uses the sender name when available', () => {
+            expect(getSenderFromMessage(buildMessage())).toEqual('Jane Smith');
+        });
+
+        it('falls back to the address when the name is empty', () => {
+            expect(getSenderFromMessage(buildMessage({ Sender: { Address: 'jane@example.com', Name: '' } }))).toEqual(
+                'jane@example.com'
+            );
+        });
+
+        it('returns undefined when there is no sender address', () => {
+            expect(getSenderFromMessage(buildMessage({ Sender: { Address: '' } }))).toBeUndefined();
+            expect(getSenderFromMessage(undefined)).toBeUndefined();
+        });
+    });
+
+    describe('getCreateEventFromMessagePayload', () => {
+        it('forwards only messageID, subject and sender, never the body', () => {
+            const payload = getCreateEventFromMessagePayload(buildMessage({ Body: 'super secret body' }), 84000);
+
+            expect(payload).toEqual({
+                messageID: 'message-123',
+                subject: 'Project review',
+                sender: 'Jane Smith',
+                start: 84000,
+            });
+            expect(payload).not.toHaveProperty('body');
+            expect(payload).not.toHaveProperty('Body');
+        });
+
+        it('omits `start` for the menu action (undefined start)', () => {
+            const payload = getCreateEventFromMessagePayload(buildMessage());
+
+            expect(payload?.start).toBeUndefined();
+        });
+
+        it('normalises a missing subject to an empty string', () => {
+            const payload = getCreateEventFromMessagePayload(buildMessage({ Subject: '' }));
+
+            expect(payload?.subject).toEqual('');
+        });
+
+        it('returns undefined when the message is undefined', () => {
+            expect(getCreateEventFromMessagePayload(undefined)).toBeUndefined();
+        });
+    });
+});

--- a/applications/mail/src/app/helpers/calendar/createEventFromMessage.ts
+++ b/applications/mail/src/app/helpers/calendar/createEventFromMessage.ts
@@ -1,0 +1,33 @@
+import type { Message } from '@proton/shared/lib/interfaces/mail/Message';
+
+/**
+ * Derive a display sender string from a message. Falls back to the address when
+ * no name is present, and omits the sender entirely when there is no address.
+ * Only first-party metadata is used; no decrypted body content is touched.
+ */
+export const getSenderFromMessage = (message?: Pick<Message, 'Sender'>) => {
+    const sender = message?.Sender;
+    if (!sender?.Address) {
+        return undefined;
+    }
+    return sender.Name || sender.Address;
+};
+
+/**
+ * Build the minimal payload sent to Calendar to initialise the event editor.
+ * Only `messageID`, `subject` and optionally `sender` are forwarded - never the
+ * message body. `start` is the drop target timestamp (set for drag & drop,
+ * undefined for the "Add to Calendar" menu action which uses Calendar defaults).
+ */
+export const getCreateEventFromMessagePayload = (message?: Pick<Message, 'ID' | 'Subject' | 'Sender'>, start?: number) => {
+    if (!message) {
+        return undefined;
+    }
+
+    return {
+        messageID: message.ID,
+        subject: message.Subject || '',
+        sender: getSenderFromMessage(message),
+        start,
+    };
+};

--- a/applications/mail/src/app/hooks/drawer/useCreateCalendarEventFromMessage.ts
+++ b/applications/mail/src/app/hooks/drawer/useCreateCalendarEventFromMessage.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { useConfig } from '@proton/app-context/useConfig';
+import useDrawer from '@proton/components/hooks/drawer/useDrawer';
+import { getAppHref } from '@proton/shared/lib/apps/helper';
+import { getLocalIDFromPathname } from '@proton/shared/lib/authentication/pathnameHelper';
+import { APPS } from '@proton/shared/lib/constants';
+import {
+    addParentAppToUrl,
+    getDrawerAppFromURL,
+    getIsDrawerPostMessage,
+    postMessageToIframe,
+} from '@proton/shared/lib/drawer/helpers';
+import { DRAWER_EVENTS } from '@proton/shared/lib/drawer/interfaces';
+
+/**
+ * Opens the Calendar drawer and asks it to initialise the standard event editor
+ * prefilled from a Mail message (subject, optional sender). This is the
+ * accessible "Add to Calendar" entry point that shares the same underlying
+ * `CALENDAR_CREATE_EVENT_FROM_MAIL` message as drag & drop.
+ */
+const useCreateCalendarEventFromMessage = () => {
+    const { appInView, setAppInView, iframeSrcMap, setIframeSrcMap } = useDrawer();
+    const { APP_NAME: currentApp } = useConfig();
+    const pendingRef = useRef<{
+        messageID: string;
+        subject: string;
+        sender?: string;
+    }>();
+
+    // Flush the pending create request once the Calendar iframe reports READY
+    // (i.e. after the drawer has been cold-opened and mounted).
+    useEffect(() => {
+        const handleMessage = (event: MessageEvent) => {
+            if (!getIsDrawerPostMessage(event)) {
+                return;
+            }
+
+            if (event.data.type !== DRAWER_EVENTS.READY) {
+                return;
+            }
+
+            if (getDrawerAppFromURL(event.origin) !== APPS.PROTONCALENDAR) {
+                return;
+            }
+
+            const pending = pendingRef.current;
+            if (!pending) {
+                return;
+            }
+            pendingRef.current = undefined;
+
+            postMessageToIframe(
+                {
+                    type: DRAWER_EVENTS.CALENDAR_CREATE_EVENT_FROM_MAIL,
+                    payload: pending,
+                },
+                APPS.PROTONCALENDAR
+            );
+        };
+
+        window.addEventListener('message', handleMessage);
+
+        return () => {
+            window.removeEventListener('message', handleMessage);
+        };
+    }, []);
+
+    return useCallback(
+        ({ messageID, subject, sender }: { messageID: string; subject: string; sender?: string }) => {
+            // Calendar already mounted in the drawer: talk to it directly.
+            if (appInView === APPS.PROTONCALENDAR && iframeSrcMap[APPS.PROTONCALENDAR]) {
+                postMessageToIframe(
+                    {
+                        type: DRAWER_EVENTS.CALENDAR_CREATE_EVENT_FROM_MAIL,
+                        payload: { messageID, subject, sender },
+                    },
+                    APPS.PROTONCALENDAR
+                );
+                return;
+            }
+
+            // Otherwise open the drawer and defer the request until the iframe
+            // has mounted and reported READY.
+            pendingRef.current = { messageID, subject, sender };
+            setAppInView(APPS.PROTONCALENDAR);
+
+            if (!iframeSrcMap[APPS.PROTONCALENDAR]) {
+                const localID = getLocalIDFromPathname(window.location.pathname);
+                const appHref = getAppHref('/', APPS.PROTONCALENDAR, localID);
+
+                setIframeSrcMap((map) => ({
+                    ...map,
+                    [APPS.PROTONCALENDAR]: addParentAppToUrl(appHref, currentApp),
+                }));
+            }
+        },
+        [appInView, iframeSrcMap, currentApp, setAppInView, setIframeSrcMap]
+    );
+};
+
+export default useCreateCalendarEventFromMessage;

--- a/applications/mail/src/app/hooks/drawer/useMailCalendarCreateEvent.ts
+++ b/applications/mail/src/app/hooks/drawer/useMailCalendarCreateEvent.ts
@@ -1,0 +1,80 @@
+import { useEffect } from 'react';
+
+import { useApi } from '@proton/app-context/useApi';
+import {
+    TelemetryMailCalendarCreateEventEvents,
+    TelemetryMeasurementGroups,
+} from '@proton/shared/lib/api/telemetry';
+import { APPS } from '@proton/shared/lib/constants';
+import { getIsDrawerPostMessage, postMessageToIframe } from '@proton/shared/lib/drawer/helpers';
+import { DRAWER_EVENTS } from '@proton/shared/lib/drawer/interfaces';
+import { sendTelemetryReport } from '@proton/shared/lib/helpers/metrics';
+
+import { getCreateEventFromMessagePayload } from '../../helpers/calendar/createEventFromMessage';
+import { selectDraggedMessageID } from '../../store/layout/layoutSliceSelectors';
+import { useMailStore } from '../../store/hooks';
+
+/**
+ * Listens for a Calendar drop handshake and turns it into a typed
+ * "create event from mail" request to the Calendar drawer.
+ *
+ * The actual dragged message is resolved here, only after Calendar reports a
+ * valid drop (`CALENDAR_MAIL_DROP`), and only its minimal metadata (subject,
+ * sender) is forwarded. No message body or content is ever sent.
+ */
+const useMailCalendarCreateEvent = () => {
+    const store = useMailStore();
+    const api = useApi();
+
+    useEffect(() => {
+        const handleMessage = (event: MessageEvent) => {
+            if (!getIsDrawerPostMessage(event)) {
+                return;
+            }
+
+            if (event.data.type !== DRAWER_EVENTS.CALENDAR_MAIL_DROP) {
+                return;
+            }
+
+            const { start } = event.data.payload;
+            const state = store.getState();
+
+            // Resolve the single dragged message, if any. `draggedMessageID` is
+            // only set by useListSelection when exactly one message is dragged.
+            const messageID = selectDraggedMessageID(state);
+            if (!messageID) {
+                return;
+            }
+
+            const message = state.messages[messageID];
+            const payload = getCreateEventFromMessagePayload(message?.data, start);
+            if (!payload) {
+                return;
+            }
+
+            postMessageToIframe(
+                {
+                    type: DRAWER_EVENTS.CALENDAR_CREATE_EVENT_FROM_MAIL,
+                    payload,
+                },
+                APPS.PROTONCALENDAR
+            );
+
+            void sendTelemetryReport({
+                api,
+                measurementGroup: TelemetryMeasurementGroups.mailCalendarCreateEvent,
+                event: TelemetryMailCalendarCreateEventEvents.create_event,
+                silence: true,
+                dimensions: { entry_point: 'drag_drop' },
+            });
+        };
+
+        window.addEventListener('message', handleMessage);
+
+        return () => {
+            window.removeEventListener('message', handleMessage);
+        };
+    }, [store, api]);
+};
+
+export default useMailCalendarCreateEvent;

--- a/applications/mail/src/app/hooks/drawer/useMailDrawer.tsx
+++ b/applications/mail/src/app/hooks/drawer/useMailDrawer.tsx
@@ -1,3 +1,6 @@
+import type { DragEvent } from 'react';
+import { useEffect, useRef } from 'react';
+
 import CalendarDrawerAppButton from '@proton/components/components/drawer/drawerAppButtons/CalendarDrawerAppButton';
 import ContactDrawerAppButton from '@proton/components/components/drawer/drawerAppButtons/ContactDrawerAppButton';
 import LumoDrawerAppButton from '@proton/components/components/drawer/drawerAppButtons/LumoDrawerAppButton';
@@ -10,26 +13,93 @@ import useAllowedProducts from '@proton/components/containers/organization/acces
 import useDrawer from '@proton/components/hooks/drawer/useDrawer';
 import { Product } from '@proton/shared/lib/ProductEnum';
 import { APPS } from '@proton/shared/lib/constants';
-import { isAppInView } from '@proton/shared/lib/drawer/helpers';
-import { DRAWER_NATIVE_APPS } from '@proton/shared/lib/drawer/interfaces';
+import { isAppInView, postMessageToIframe } from '@proton/shared/lib/drawer/helpers';
+import { DRAWER_EVENTS, DRAWER_NATIVE_APPS } from '@proton/shared/lib/drawer/interfaces';
+import clsx from '@proton/utils/clsx';
 import isTruthy from '@proton/utils/isTruthy';
 
 import FeatureTourDrawerButton from '../../components/drawer/FeatureTourDrawerButton';
+import { useMailSelector } from '../../store/hooks';
+import { selectDraggingElementsCount } from '../../store/layout/layoutSliceSelectors';
+import useMailCalendarCreateEvent from './useMailCalendarCreateEvent';
 
 const useMailDrawer = () => {
-    const { appInView, showDrawerSidebar } = useDrawer();
+    const { appInView, showDrawerSidebar, toggleDrawerApp } = useDrawer();
     const canShowFeatureTourDrawerButton = useDisplayFeatureTourDrawerButton();
 
     const [allowedProducts, loadingAllowedProducts] = useAllowedProducts();
     const isLumoInMailEnabled = useLumoInMail();
 
+    const draggingElementsCount = useMailSelector(selectDraggingElementsCount);
+    const isSingleMessageDrag = draggingElementsCount === 1;
+
+    // Handle the Calendar drop handshake (CALENDAR_MAIL_DROP -> resolve message
+    // -> CALENDAR_CREATE_EVENT_FROM_MAIL).
+    useMailCalendarCreateEvent();
+
+    // Hover-to-open: while a single message is dragged over the Calendar icon,
+    // open the drawer after a short delay so the user can drop onto a time slot.
+    const calendarIsInView = appInView === APPS.PROTONCALENDAR;
+    const hoverOpenTimerRef = useRef<ReturnType<typeof setTimeout>>();
+    const openCalendarDrawer = () => {
+        if (!calendarIsInView) {
+            toggleDrawerApp({ app: APPS.PROTONCALENDAR })();
+        }
+    };
+    const handleCalendarDragEnter = (event: DragEvent) => {
+        if (!isSingleMessageDrag) {
+            return;
+        }
+        event.preventDefault();
+        if (!hoverOpenTimerRef.current) {
+            hoverOpenTimerRef.current = setTimeout(openCalendarDrawer, 300);
+        }
+    };
+    const handleCalendarDragLeave = () => {
+        if (hoverOpenTimerRef.current) {
+            clearTimeout(hoverOpenTimerRef.current);
+            hoverOpenTimerRef.current = undefined;
+        }
+    };
+
+    // Notify the Calendar drawer (when open) that a Mail drag is active and how
+    // many messages it carries, without leaking any message content. Calendar
+    // uses this to enable its drop target and later request the actual message.
+    useEffect(() => {
+        if (!calendarIsInView) {
+            return;
+        }
+        postMessageToIframe(
+            {
+                type: DRAWER_EVENTS.CALENDAR_MAIL_DRAG_STATE,
+                payload: { active: draggingElementsCount > 0, count: draggingElementsCount },
+            },
+            APPS.PROTONCALENDAR
+        );
+    }, [calendarIsInView, draggingElementsCount]);
+
+    useEffect(
+        () => () => {
+            if (hoverOpenTimerRef.current) {
+                clearTimeout(hoverOpenTimerRef.current);
+            }
+        },
+        []
+    );
+
     const drawerSidebarButtons = [
         <ContactDrawerAppButton aria-expanded={isAppInView(DRAWER_NATIVE_APPS.CONTACTS, appInView)} />,
         allowedProducts.has(Product.Calendar) && (
-            <CalendarDrawerAppButton
-                aria-expanded={isAppInView(APPS.PROTONCALENDAR, appInView)}
-                disabled={loadingAllowedProducts}
-            />
+            <span
+                className={clsx(isSingleMessageDrag && 'drawer-sidebar-button--drop-target')}
+                onDragEnter={handleCalendarDragEnter}
+                onDragLeave={handleCalendarDragLeave}
+            >
+                <CalendarDrawerAppButton
+                    aria-expanded={isAppInView(APPS.PROTONCALENDAR, appInView)}
+                    disabled={loadingAllowedProducts}
+                />
+            </span>
         ),
         <SecurityCenterDrawerAppButton aria-expanded={isAppInView(DRAWER_NATIVE_APPS.SECURITY_CENTER, appInView)} />,
         isLumoInMailEnabled ? (

--- a/applications/mail/src/app/hooks/list/useListSelection.ts
+++ b/applications/mail/src/app/hooks/list/useListSelection.ts
@@ -89,11 +89,18 @@ export const useListSelection = ({
     // Helps components outside the list to know when an element drag is in progress.
     useEffect(() => {
         dispatch(layoutActions.setDraggingElements(isDraggingElements));
+        dispatch(layoutActions.setDraggingElementsCount(draggedIDs.length));
+        // Only retain the dragged ID for single-message drags, which is what the
+        // "create calendar event from mail" target supports. Multi-message drags
+        // keep no IDs in global state.
+        dispatch(layoutActions.setDraggedMessageID(draggedIDs.length === 1 ? draggedIDs[0] : null));
 
         return () => {
             dispatch(layoutActions.setDraggingElements(false));
+            dispatch(layoutActions.setDraggingElementsCount(0));
+            dispatch(layoutActions.setDraggedMessageID(null));
         };
-    }, [isDraggingElements, dispatch]);
+    }, [isDraggingElements, draggedIDs.length, draggedIDs, dispatch]);
 
     const draggedIDsMap = useMemo<{ [ID: string]: boolean }>(() => {
         return draggedIDs.reduce(

--- a/applications/mail/src/app/store/layout/layoutSlice.spec.ts
+++ b/applications/mail/src/app/store/layout/layoutSlice.spec.ts
@@ -1,0 +1,26 @@
+import { layoutActions, layoutReducer, layoutInitialState } from './layoutSlice';
+
+describe('layout slice', () => {
+    const getState = () => layoutReducer.layout(layoutInitialState, layoutActions.setDraggingElements(true));
+
+    it('tracks dragging count', () => {
+        const state = layoutReducer.layout(layoutInitialState, layoutActions.setDraggingElementsCount(1));
+        expect(state.draggingElementsCount).toEqual(1);
+        expect(state.draggingElements).toEqual(false);
+    });
+
+    it('stores the dragged message ID only for single-message drags', () => {
+        const state = layoutReducer.layout(layoutInitialState, layoutActions.setDraggedMessageID('message-123'));
+        expect(state.draggedMessageID).toEqual('message-123');
+    });
+
+    it('defaults to no dragged message ID and zero count', () => {
+        expect(layoutInitialState.draggingElementsCount).toEqual(0);
+        expect(layoutInitialState.draggedMessageID).toBeNull();
+    });
+
+    it('still exposes the boolean draggingElements flag', () => {
+        const state = getState();
+        expect(state.draggingElements).toEqual(true);
+    });
+});

--- a/applications/mail/src/app/store/layout/layoutSlice.ts
+++ b/applications/mail/src/app/store/layout/layoutSlice.ts
@@ -5,6 +5,20 @@ interface LayoutState {
     sidebarExpanded: boolean;
     selectAll: boolean;
     draggingElements: boolean;
+    /**
+     * Number of elements currently being dragged out of the mailbox list.
+     * `1` means a single message is eligible for the "create calendar event"
+     * drop target; anything greater than `1` disables it (multi-select drags
+     * are reserved for moving messages between folders/labels).
+     */
+    draggingElementsCount: number;
+    /**
+     * The message ID being dragged, but only when exactly one message is
+     * dragged (`draggingElementsCount === 1`). Kept local to Mail and only
+     * resolved into event metadata after a valid Calendar drop. `null` for
+     * multi-message drags so no IDs are retained unnecessarily.
+     */
+    draggedMessageID?: string | null;
 }
 
 export const layoutInitialState: LayoutState = {
@@ -18,6 +32,8 @@ export const layoutInitialState: LayoutState = {
      * outside of the list (category tabs, ...) use it to show their affordance.
      */
     draggingElements: false,
+    draggingElementsCount: 0,
+    draggedMessageID: null,
 };
 
 const name = 'layout';
@@ -36,6 +52,12 @@ const layoutSlice = createSlice({
         },
         setDraggingElements: (state, action: PayloadAction<boolean>) => {
             state.draggingElements = action.payload;
+        },
+        setDraggingElementsCount: (state, action: PayloadAction<number>) => {
+            state.draggingElementsCount = action.payload;
+        },
+        setDraggedMessageID: (state, action: PayloadAction<string | null>) => {
+            state.draggedMessageID = action.payload;
         },
     },
 });

--- a/applications/mail/src/app/store/layout/layoutSliceSelectors.ts
+++ b/applications/mail/src/app/store/layout/layoutSliceSelectors.ts
@@ -7,3 +7,5 @@ const layout = (state: MailState) => state.layout;
 export const selectLayoutIsExpanded = createSelector([layout], (layout) => layout.sidebarExpanded);
 export const selectSelectAll = createSelector([layout], (layout) => layout.selectAll);
 export const selectDraggingElements = createSelector([layout], (layout) => layout.draggingElements);
+export const selectDraggingElementsCount = createSelector([layout], (layout) => layout.draggingElementsCount);
+export const selectDraggedMessageID = createSelector([layout], (layout) => layout.draggedMessageID);

--- a/packages/components/components/drawer/DrawerSidebar.scss
+++ b/packages/components/components/drawer/DrawerSidebar.scss
@@ -55,6 +55,13 @@ im.$media-expressions: $media-expressions;
 		}
 	}
 
+	// Highlight the Calendar drawer button while a single Mail message is being
+	// dragged, signalling that it is a valid drop target to create an event.
+	.drawer-sidebar-button--drop-target .drawer-sidebar-button {
+		border-color: var(--primary);
+		background-color: var(--interaction-default-hover);
+	}
+
 	&--hide-on-tablet {
 		@include im.media('<=#{em($breakpoint-for-drawer, 16)}') {
 			display: none;

--- a/packages/shared/lib/api/telemetry.ts
+++ b/packages/shared/lib/api/telemetry.ts
@@ -48,6 +48,7 @@ export enum TelemetryMeasurementGroups {
     categoriesView = 'mail.any.categories_view',
     passNudge = 'mail.web.pass_nudge',
     mailNewsletterSubscriptions = 'mail.web.newsletter_subscriptions',
+    mailCalendarCreateEvent = 'mail.web.calendar_create_event',
     unlimitedOffer2025 = 'any.web.unlimited_offer_2025',
     unlimitedToDuoOffer = 'any.web.unlimited_to_duo_offer',
     esMigrationTool = 'mail.es_migration_tool',
@@ -311,6 +312,10 @@ export enum TelemetryDesktopEvents {
 export enum TelemetryMailEvents {
     privacy_dropdown_opened = 'privacy_dropdown_opened',
     snooze_open_dropdown = 'snooze_open_dropdown',
+}
+
+export enum TelemetryMailCalendarCreateEventEvents {
+    create_event = 'mail_calendar_create_event',
 }
 
 export enum TelemetryMailForegroundEvents {

--- a/packages/shared/lib/drawer/interfaces.ts
+++ b/packages/shared/lib/drawer/interfaces.ts
@@ -62,6 +62,11 @@ export enum DRAWER_EVENTS {
     REFRESH_WIDGET = 'outside-refresh-widget',
     OPEN_CONTACT_MODAL = 'open-contact-modal',
     OPEN_BUG_MODAL = 'open-bug-modal',
+
+    // Mail to calendar create-event events
+    CALENDAR_MAIL_DRAG_STATE = 'outside-calendar-mail-drag-state',
+    CALENDAR_MAIL_DROP = 'outside-calendar-mail-drop',
+    CALENDAR_CREATE_EVENT_FROM_MAIL = 'outside-calendar-create-event-from-mail',
 }
 
 // Global inside iframe events
@@ -224,6 +229,46 @@ type OPEN_BUG_MODAL = {
     payload?: BugModalPrefill;
 };
 
+/**
+ * Sent from Mail to Calendar while an email drag is active. Contains only
+ * generic state (no message metadata) so that decrypted content never leaves
+ * Mail until the user actually drops onto Calendar.
+ */
+interface CALENDAR_MAIL_DRAG_STATE {
+    type: DRAWER_EVENTS.CALENDAR_MAIL_DRAG_STATE;
+    payload: {
+        active: boolean;
+        count: number;
+    };
+}
+
+/**
+ * Sent from Calendar (inside the drawer iframe) to Mail when the user drops a
+ * dragged email onto a day/week time slot. Carries the computed start timestamp.
+ */
+interface CALENDAR_MAIL_DROP {
+    type: DRAWER_EVENTS.CALENDAR_MAIL_DROP;
+    payload: {
+        start: number;
+    };
+}
+
+/**
+ * Sent from Mail to Calendar after resolving the dropped message, carrying the
+ * minimal metadata needed to initialise the standard event editor. `start` is
+ * the drop target timestamp for drag/drop; it is omitted for the "Add to
+ * Calendar" menu action, which uses Calendar's default date/time.
+ */
+interface CALENDAR_CREATE_EVENT_FROM_MAIL {
+    type: DRAWER_EVENTS.CALENDAR_CREATE_EVENT_FROM_MAIL;
+    payload: {
+        messageID: string;
+        subject: string;
+        sender?: string;
+        start?: number;
+    };
+}
+
 export type DRAWER_ACTION =
     | CLOSE
     | SHOW
@@ -243,7 +288,10 @@ export type DRAWER_ACTION =
     | REQUEST_OPEN_EVENTS
     | REFRESH_WIDGET
     | OPEN_CONTACT_MODAL
-    | OPEN_BUG_MODAL;
+    | OPEN_BUG_MODAL
+    | CALENDAR_MAIL_DRAG_STATE
+    | CALENDAR_MAIL_DROP
+    | CALENDAR_CREATE_EVENT_FROM_MAIL;
 
 /**
  * QUICK SETTINGS

--- a/packages/shared/tests/drawer/drawer.spec.ts
+++ b/packages/shared/tests/drawer/drawer.spec.ts
@@ -141,6 +141,23 @@ describe('drawer helpers', () => {
 
             expect(getIsDrawerPostMessage(event, hostname)).toBeFalsy();
         });
+
+        it('should recognise the mail-to-calendar create-event messages', () => {
+            const mailCalendarCreateEventTypes = [
+                DRAWER_EVENTS.CALENDAR_MAIL_DRAG_STATE,
+                DRAWER_EVENTS.CALENDAR_MAIL_DROP,
+                DRAWER_EVENTS.CALENDAR_CREATE_EVENT_FROM_MAIL,
+            ];
+
+            mailCalendarCreateEventTypes.forEach((type) => {
+                const event = {
+                    origin: `https://${drawerAuthorizedApps[0]}.proton.me`,
+                    data: { type },
+                } as MessageEvent;
+
+                expect(getIsDrawerPostMessage(event, hostname)).toBeTruthy();
+            });
+        });
     });
 
     describe('postMessageFromIframe', () => {


### PR DESCRIPTION
## Description

Add a "create Calendar event from email" capability to Mail, with drag-and-drop as the primary desktop interaction and an "Add to Calendar" menu action as the accessible alternative.

Dropping a single Mail message onto the Calendar drawer's grid opens the standard event editor with:

- the email subject as the event title
- the drop position as the event start time (day/week) - or the dropped day's start time on month view
- a minimal `From: <sender>` description reference
- the user's normal default calendar and event defaults
- no automatic save

It reuses the existing Mail drag system, Calendar drawer iframe, drawer messaging protocol and Calendar event editor - no parallel drag or persistence path is introduced.

## Implementation notes

- Three new typed drawer events in `packages/shared/lib/drawer/interfaces.ts`: `CALENDAR_MAIL_DRAG_STATE`, `CALENDAR_MAIL_DROP` and `CALENDAR_CREATE_EVENT_FROM_MAIL`.
- Mail layout state now tracks a single-message drag count and (only for single-message drags) the dragged ID; multi-message drags retain no ID in global state.
- The Calendar day/week/month grids become drop targets via `useCalendarMailDrop`; the slot date/time is computed with the existing `getTargetMinutes`/`getNewTime` helpers, then reported back to Mail via `CALENDAR_MAIL_DROP`.
- Mail resolves the dragged message and forwards only `messageID`, `subject` and `sender` metadata (never the body) via `CALENDAR_CREATE_EVENT_FROM_MAIL`.
- Calendar opens the existing editor through `interactiveRef.createEventFromMail`.
- "Add to Calendar" menu action opens the drawer (waiting for the iframe `READY` handshake on a cold open) and prefills subject/sender with default date/time.
- The Calendar drawer icon highlights as a drop target during a single-message drag and opens on hover.
- Interaction telemetry `mail_calendar_create_event` with a `drag_drop` / `menu_action` entry-point dimension (no message content).

## Testing

New unit tests (which I verified pass via a local `node --test` harness, since I could not run the monorepo install):

- `dateHelpers.spec.ts` - drop-to-timestamp mapping for day, week and month grids (snapping, clamping, guards).
- `createEventFromMessage.test.ts` - only `messageID`/`subject`/`sender` forwarded (asserts no body), sender fallback, missing-subject normalisation.
- `layoutSlice.spec.ts` - drag count / dragged-ID transitions.
- `drawer.spec.ts` - the three new event types are recognised as drawer messages.

Note: I was unable to run `yarn install` in my environment (the `@proton/*` scope registry and `vendor/*` workspaces are only reachable from Proton's internal network), so the CI `prettier` / `eslint` / `check-types` gates have not been executed on my side. The changed files parse cleanly under TypeScript, but please run CI. Also, the new measurement group `mail.web.calendar_create_event` requires backend whitelisting or it will be silently dropped.

## Out of scope

Month view maps a drop to the start of the dropped day (default-time event) rather than an exact time. Stable email backlinks, conversation-level events and date/time extraction are left for follow-ups.