### PR TITLE
Fix Authenticator key storage on KWallet

### DIFF
--- a/applications/authenticator/src-tauri/src/crypto.rs
+++ b/applications/authenticator/src-tauri/src/crypto.rs
@@ -1,6 +1,6 @@
 use rand::{rngs::SysRng, TryRng};
 
-const KEY_LENGTH: usize = 32;
+pub(crate) const KEY_LENGTH: usize = 32;
 
 pub fn generate_encryption_key() -> Vec<u8> {
     random_bytes(KEY_LENGTH)

--- a/applications/authenticator/src-tauri/src/storage_key.rs
+++ b/applications/authenticator/src-tauri/src/storage_key.rs
@@ -50,8 +50,7 @@ fn secret_to_b64(secret: &Vec<u8>) -> String {
 #[specta::specta]
 pub fn get_storage_key(key_id: &str) -> Result<String, KeyringError> {
     let b64 = Entry::new(SERVICE_NAME, key_id)
-        .and_then(|entry| entry.get_secret())
-        .map(|secret| secret_to_b64(&secret))
+        .and_then(|entry| entry.get_password())
         .map_err(KeyringError::from)?;
 
     Ok(b64)
@@ -64,13 +63,14 @@ pub fn get_storage_key(key_id: &str) -> Result<String, KeyringError> {
 pub fn generate_storage_key(key_id: &str) -> Result<String, KeyringError> {
     let entry = Entry::new(SERVICE_NAME, key_id).map_err(KeyringError::from)?;
 
-    if let Ok(secret) = entry.get_secret() {
-        return Ok(secret_to_b64(&secret));
+    if let Ok(secret) = entry.get_password() {
+        return Ok(secret);
     }
 
     let secret = generate_encryption_key();
-    entry.set_secret(&secret).map_err(KeyringError::from)?;
-    Ok(secret_to_b64(&secret))
+    let b64 = secret_to_b64(&secret);
+    entry.set_password(&b64).map_err(KeyringError::from)?;
+    Ok(b64)
 }
 
 #[tauri::command]

--- a/applications/authenticator/src-tauri/src/storage_key.rs
+++ b/applications/authenticator/src-tauri/src/storage_key.rs
@@ -1,4 +1,4 @@
-use crate::crypto::generate_encryption_key;
+use crate::crypto::{generate_encryption_key, KEY_LENGTH};
 use base64::{engine::general_purpose, Engine as _};
 use keyring::{Entry, Error};
 use serde::Serialize;
@@ -40,8 +40,45 @@ const SERVICE_NAME: &str = if cfg!(debug_assertions) {
     "com.proton.authenticator"
 };
 
-fn secret_to_b64(secret: &Vec<u8>) -> String {
+fn secret_to_b64(secret: &[u8]) -> String {
     general_purpose::STANDARD.encode(secret)
+}
+
+fn get_storage_key_from_entry(entry: &Entry) -> Result<String, KeyringError> {
+    let secret = match entry.get_password() {
+        Ok(secret)
+            if general_purpose::STANDARD
+                .decode(&secret)
+                .is_ok_and(|decoded| decoded.len() == KEY_LENGTH) =>
+        {
+            return Ok(secret)
+        }
+        // Older versions stored the 32-byte key directly through `set_secret`.
+        Ok(_) | Err(Error::BadEncoding(_)) => entry.get_secret().map_err(KeyringError::from)?,
+        Err(err) => return Err(KeyringError::from(err)),
+    };
+
+    if secret.len() != KEY_LENGTH {
+        return Err(KeyringError::BadEncoding(format!(
+            "Stored key must be {KEY_LENGTH} bytes"
+        )));
+    }
+
+    store_storage_key(entry, &secret)
+}
+
+fn store_storage_key(entry: &Entry, secret: &[u8]) -> Result<String, KeyringError> {
+    let b64 = secret_to_b64(secret);
+    entry.set_password(&b64).map_err(KeyringError::from)?;
+    Ok(b64)
+}
+
+fn generate_storage_key_from_entry(entry: &Entry) -> Result<String, KeyringError> {
+    match get_storage_key_from_entry(entry) {
+        Ok(secret) => Ok(secret),
+        Err(KeyringError::NoEntry(_)) => store_storage_key(entry, &generate_encryption_key()),
+        Err(err) => Err(err),
+    }
 }
 
 /// Retrieves a local key by `key_id`. Consumers should parse the
@@ -49,11 +86,8 @@ fn secret_to_b64(secret: &Vec<u8>) -> String {
 #[tauri::command]
 #[specta::specta]
 pub fn get_storage_key(key_id: &str) -> Result<String, KeyringError> {
-    let b64 = Entry::new(SERVICE_NAME, key_id)
-        .and_then(|entry| entry.get_password())
-        .map_err(KeyringError::from)?;
-
-    Ok(b64)
+    let entry = Entry::new(SERVICE_NAME, key_id).map_err(KeyringError::from)?;
+    get_storage_key_from_entry(&entry)
 }
 
 /// Generates a local key and attempts to save it to the OS's keyring.
@@ -62,15 +96,7 @@ pub fn get_storage_key(key_id: &str) -> Result<String, KeyringError> {
 #[specta::specta]
 pub fn generate_storage_key(key_id: &str) -> Result<String, KeyringError> {
     let entry = Entry::new(SERVICE_NAME, key_id).map_err(KeyringError::from)?;
-
-    if let Ok(secret) = entry.get_password() {
-        return Ok(secret);
-    }
-
-    let secret = generate_encryption_key();
-    let b64 = secret_to_b64(&secret);
-    entry.set_password(&b64).map_err(KeyringError::from)?;
-    Ok(b64)
+    generate_storage_key_from_entry(&entry)
 }
 
 #[tauri::command]
@@ -79,4 +105,66 @@ pub fn remove_storage_key(key_id: &str) -> Result<(), KeyringError> {
     Entry::new(SERVICE_NAME, key_id)
         .and_then(|entry| entry.delete_credential())
         .map_err(KeyringError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use keyring::mock::MockCredential;
+
+    const LEGACY_KEY: [u8; 32] = [0xff; 32];
+    const ENCODED_KEY: &str = "//////////////////////////////////////////8=";
+
+    fn mock_entry() -> Entry {
+        Entry::new_with_credential(Box::new(MockCredential::default()))
+    }
+
+    #[test]
+    fn round_trips_storage_key_as_base64_text() {
+        let entry = mock_entry();
+
+        let stored = match store_storage_key(&entry, &LEGACY_KEY) {
+            Ok(stored) => stored,
+            Err(_) => panic!("storage key should be stored"),
+        };
+
+        assert_eq!(stored, ENCODED_KEY);
+        assert_eq!(entry.get_password().unwrap(), ENCODED_KEY);
+        assert!(matches!(
+            get_storage_key_from_entry(&entry),
+            Ok(key) if key == ENCODED_KEY
+        ));
+    }
+
+    #[test]
+    fn migrates_legacy_binary_key_to_base64_text() {
+        let entry = mock_entry();
+        entry.set_secret(&LEGACY_KEY).unwrap();
+
+        let key = match get_storage_key_from_entry(&entry) {
+            Ok(key) => key,
+            Err(_) => panic!("legacy storage key should be migrated"),
+        };
+
+        assert_eq!(key, ENCODED_KEY);
+        assert_eq!(entry.get_password().unwrap(), ENCODED_KEY);
+    }
+
+    #[test]
+    fn does_not_replace_key_when_keyring_read_fails() {
+        let entry = mock_entry();
+        let mock = entry
+            .get_credential()
+            .downcast_ref::<MockCredential>()
+            .unwrap();
+        mock.set_error(Error::Invalid(
+            "mock storage error".to_owned(),
+            "test error".to_owned(),
+        ));
+
+        let result = generate_storage_key_from_entry(&entry);
+
+        assert!(matches!(result, Err(KeyringError::Invalid(_))));
+        assert!(matches!(entry.get_secret(), Err(Error::NoEntry)));
+    }
 }


### PR DESCRIPTION
## What changed

- Store the Authenticator storage key's existing Base64 representation through the keyring password API.
- Read and validate that textual representation through the same API.
- Migrate legacy raw 32-byte keys to Base64 text without changing the key.
- Generate a new key only when no credential exists; preserve other keyring errors.

## Why

Proton Authenticator returns its storage key to the application as Base64 text, but previously wrote the underlying random bytes through `set_secret`. The Secret Service backend in `keyring` 3.6.3 labels those bytes as `text/plain`. Any Secret Service provider that validates the declared text content can reject arbitrary binary data. KWallet is the provider on which this failure was reproduced.

Persisting the Base64 representation makes the payload match its declared text type across keyring backends. Migrating existing raw credentials preserves keys created by earlier versions, while propagating non-missing-entry errors prevents a temporary keyring failure from replacing an existing key.

## Verification

- Reproduced the binary-storage failure against KWallet with `keyring` 3.6.3.
- Verified first-run key creation and retrieval after restarting Proton Authenticator on NixOS with KDE Plasma.
- Added unit coverage for Base64 text round trips, legacy binary-key migration, and non-destructive keyring error handling.
- Rust formatting, Clippy with warnings denied, and all 4 library tests pass.
