### PR TITLE
Ignore IME keydown events in the Rooster iframe bridge

### DIFF
--- a/packages/components/components/editor/rooster/hooks/useBubbleIframeEvents.test.tsx
+++ b/packages/components/components/editor/rooster/hooks/useBubbleIframeEvents.test.tsx
@@ -1,0 +1,83 @@
+import { useRef } from 'react';
+
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+import { cloneEvent } from '@proton/shared/lib/helpers/events';
+
+import { ROOSTER_EDITOR_WRAPPER_ID } from '../../constants';
+import useBubbleIframeEvents from './useBubbleIframeEvents';
+
+jest.mock('@proton/shared/lib/helpers/events', () => ({
+    cloneEvent: jest.fn((event: Event) => new Event(event.type)),
+    isKeyboardEvent: (event: Event) => 'key' in event,
+}));
+
+jest.mock('@proton/shared/lib/shortcuts/helpers', () => ({
+    isValidShortcut: jest.fn(() => false),
+}));
+
+jest.mock('@proton/shared/lib/shortcuts/mail', () => ({
+    editorShortcuts: {},
+}));
+
+const TestEditor = () => {
+    const iframeRef = useRef<HTMLIFrameElement>(null);
+    useBubbleIframeEvents(iframeRef);
+
+    return (
+        <iframe
+            ref={(iframe) => {
+                iframeRef.current = iframe;
+                if (iframe?.contentDocument?.body && !iframe.contentDocument.getElementById(ROOSTER_EDITOR_WRAPPER_ID)) {
+                    const wrapper = iframe.contentDocument.createElement('div');
+                    wrapper.id = ROOSTER_EDITOR_WRAPPER_ID;
+                    iframe.contentDocument.body.appendChild(wrapper);
+                }
+            }}
+            title="Test editor"
+        />
+    );
+};
+
+const getWrapper = () => {
+    const iframe = document.querySelector('iframe') as HTMLIFrameElement;
+    const wrapper = iframe.contentDocument?.getElementById(ROOSTER_EDITOR_WRAPPER_ID);
+    expect(wrapper).not.toBeNull();
+    return wrapper as HTMLElement;
+};
+
+describe('useBubbleIframeEvents IME handling', () => {
+    beforeEach(() => {
+        jest.mocked(cloneEvent).mockClear();
+    });
+
+    it('does not bubble keydown while composition is active', async () => {
+        render(<TestEditor />);
+        const wrapper = getWrapper();
+        const event = new KeyboardEvent('keydown', { key: 'Process', isComposing: true, bubbles: true });
+
+        fireEvent(wrapper, event);
+
+        await waitFor(() => expect(cloneEvent).not.toHaveBeenCalled());
+    });
+
+    it('does not bubble keydown with the IME keyCode fallback', async () => {
+        render(<TestEditor />);
+        const wrapper = getWrapper();
+        const event = new KeyboardEvent('keydown', { key: 'Process', bubbles: true });
+        Object.defineProperty(event, 'keyCode', { value: 229 });
+
+        fireEvent(wrapper, event);
+
+        await waitFor(() => expect(cloneEvent).not.toHaveBeenCalled());
+    });
+
+    it('continues to bubble normal keydown events', async () => {
+        render(<TestEditor />);
+        const wrapper = getWrapper();
+
+        fireEvent.keyDown(wrapper, { key: 'Escape' });
+
+        await waitFor(() => expect(cloneEvent).toHaveBeenCalledTimes(1));
+    });
+});

--- a/packages/components/components/editor/rooster/hooks/useBubbleIframeEvents.ts
+++ b/packages/components/components/editor/rooster/hooks/useBubbleIframeEvents.ts
@@ -10,6 +10,9 @@ import { IFRAME_EVENTS_LIST, ROOSTER_EDITOR_WRAPPER_ID } from '../../constants';
 
 const PAGE_EVENTS = [KeyboardKey.PageUp, KeyboardKey.PageDown];
 
+const isIMEKeyboardEvent = (event: Event) =>
+    isKeyboardEvent(event) && (event.isComposing || event.keyCode === 229);
+
 /**
  * Calls event.preventDefault on matched events
  * Because events occuring inside an iframe can show prompts in browsers (ex : pressing crtl+s)
@@ -48,6 +51,10 @@ const canDispatchEvent = (event: Event): boolean => {
  */
 const useBubbleIframeEvents = (iframeRef: RefObject<HTMLIFrameElement>) => {
     const handleBubble = useCallback((event: Event) => {
+        if (isIMEKeyboardEvent(event)) {
+            return;
+        }
+
         const canDispatch = canDispatchEvent(event);
         preventKeyboardEvents(event);
 


### PR DESCRIPTION
Return early from the Rooster iframe bridge for keydown events where `isComposing` is true or `keyCode` is 229. This keeps IME events out of shortcut handling and cloned event dispatch. Normal keydown behavior remains unchanged.

Add contract tests for active composition, the keyCode 229 fallback, and a normal keydown event.

## Verification

[Focused red/green GitHub Actions run](https://github.com/squarepots/WebClients/actions/runs/34090605829):

- Pre-fix: both IME cases fail; the normal keydown case passes.
- With the change: all three cases pass.
- `git diff --check` passes.

Fixes #539