### PR TITLE
Add optional total folder and subfolder unread counts

### DIFF
--- a/applications/mail/src/app/components/sidebar/MailSidebar.test.tsx
+++ b/applications/mail/src/app/components/sidebar/MailSidebar.test.tsx
@@ -5,11 +5,11 @@ import loudRejection from 'loud-rejection';
 import { useRetentionPolicies } from '@proton/account/retentionPolicies/hooks';
 import { getModelState } from '@proton/account/tests';
 import { useUserSettings } from '@proton/account/userSettings/hooks';
-import useEventManager from '@proton/components/hooks/useEventManager';
 import type { IconComponent } from '@proton/icons/component';
 import { IcFolder } from '@proton/icons/icons/IcFolder';
 import { IcFolders } from '@proton/icons/icons/IcFolders';
 import { conversationCountsActions } from '@proton/mail/store/counts/conversationCountsSlice';
+import { mailSettingsState } from '@proton/mail/store/mailSettings/mailSettings.testing';
 import { AccessType } from '@proton/shared/lib/authentication/accessType';
 import { LABEL_TYPE, MAILBOX_LABEL_IDS } from '@proton/shared/lib/constants';
 import { removeItem, setItem } from '@proton/shared/lib/helpers/storage';
@@ -55,6 +55,12 @@ const getIconMarkup = (Icon: IconComponent) => {
 
 const folder = { ID: 'folder1', Type: LABEL_TYPE.MESSAGE_FOLDER, Name: 'folder1' } as Folder;
 const subfolder = { ID: 'folder2', Type: LABEL_TYPE.MESSAGE_FOLDER, Name: 'folder2', ParentID: folder.ID } as Folder;
+const subsubfolder = {
+    ID: 'folder3',
+    Type: LABEL_TYPE.MESSAGE_FOLDER,
+    Name: 'folder3',
+    ParentID: subfolder.ID,
+} as Folder;
 const label = { ID: 'label1', Type: LABEL_TYPE.MESSAGE_LABEL, Name: 'label1' } as Label;
 const systemFolders = [
     {
@@ -110,6 +116,8 @@ const inboxMessages = { LabelID: MAILBOX_LABEL_IDS.INBOX, Unread: 3, Total: 20 }
 const allMailMessages = { LabelID: MAILBOX_LABEL_IDS.ALL_MAIL, Unread: 10000, Total: 10001 };
 const scheduledMessages = { LabelID: MAILBOX_LABEL_IDS.SCHEDULED, Unread: 1, Total: 4 };
 const folderMessages = { LabelID: folder.ID, Unread: 1, Total: 2 };
+const subfolderMessages = { LabelID: subfolder.ID, Unread: 4, Total: 5 };
+const subsubfolderMessages = { LabelID: subsubfolder.ID, Unread: 5, Total: 6 };
 const labelMessages = { LabelID: label.ID, Unread: 2, Total: 3 };
 
 describe('MailSidebar', () => {
@@ -320,28 +328,71 @@ describe('MailSidebar', () => {
 
     it('should show unread counters', async () => {
         setupTest();
+        setItem('folder_expanded_state_folder1', 'true');
+        setItem('folder_expanded_state_folder2', 'true');
+        setItem('folder_expanded_state_folder3', 'true');
 
         await mailTestRender(<MailSidebar />, {
             preloadedState: {
-                categories: getModelState([folder, label, ...systemFolders]),
-                conversationCounts: getModelState([inboxMessages, allMailMessages, folderMessages, labelMessages]),
+                categories: getModelState([folder, subfolder, subsubfolder, label, ...systemFolders]),
+                conversationCounts: getModelState([
+                    inboxMessages,
+                    allMailMessages,
+                    folderMessages,
+                    subfolderMessages,
+                    subsubfolderMessages,
+                    labelMessages,
+                ]),
             },
         });
 
         const inboxElement = screen.getByTestId(`navigation-link:inbox`);
         const allMailElement = screen.getByTestId(`navigation-link:all-mail`);
         const folderElement = screen.getByTestId(`navigation-link:${folder.ID}`);
+        const subfolderElement = screen.getByTestId(`navigation-link:${subfolder.ID}`);
         const labelElement = screen.getByTestId(`navigation-link:${label.ID}`);
 
         const inBoxLocationAside = inboxElement.querySelector('.navigation-counter-item');
         const allMailLocationAside = allMailElement.querySelector('.navigation-counter-item');
         const folderLocationAside = folderElement.querySelector('.navigation-counter-item');
+        const subfolderLocationAside = subfolderElement.querySelector('.navigation-counter-item');
         const labelLocationAside = labelElement.querySelector('.navigation-counter-item');
 
         expect(inBoxLocationAside?.innerHTML).toBe(`${inboxMessages.Unread}`);
         expect(allMailLocationAside?.innerHTML).toBe('9999+');
         expect(folderLocationAside?.innerHTML).toBe(`${folderMessages.Unread}`);
+        expect(subfolderLocationAside?.innerHTML).toBe(`${subfolderMessages.Unread}`);
         expect(labelLocationAside?.innerHTML).toBe(`${labelMessages.Unread}`);
+
+        fireEvent.click(folderElement.querySelector('button')!);
+
+        expect(folderElement.querySelector('.navigation-counter-item')?.innerHTML).toBe(
+            `${folderMessages.Unread + subfolderMessages.Unread + subsubfolderMessages.Unread}`
+        );
+
+        fireEvent.click(folderElement.querySelector('button')!);
+        fireEvent.click(subfolderElement.querySelector('button')!);
+
+        expect(subfolderElement.querySelector('.navigation-counter-item')?.innerHTML).toBe(
+            `${subfolderMessages.Unread + subsubfolderMessages.Unread}`
+        );
+    });
+
+    it('should show only direct unread counters when subfolder counts are disabled', async () => {
+        setupTest();
+        setItem('folder_expanded_state_folder1', 'false');
+
+        await mailTestRender(<MailSidebar />, {
+            preloadedState: {
+                categories: getModelState([folder, subfolder, subsubfolder, ...systemFolders]),
+                conversationCounts: getModelState([folderMessages, subfolderMessages, subsubfolderMessages]),
+                mailSettings: mailSettingsState({ IncludeSubfolderUnreadCount: false }),
+            },
+        });
+
+        const folderElement = screen.getByTestId(`navigation-link:${folder.ID}`);
+
+        expect(folderElement.querySelector('.navigation-counter-item')?.innerHTML).toBe(`${folderMessages.Unread}`);
     });
 
     it('should navigate to the label on click', async () => {

--- a/applications/mail/src/app/components/sidebar/SidebarFolders.tsx
+++ b/applications/mail/src/app/components/sidebar/SidebarFolders.tsx
@@ -8,6 +8,7 @@ import type { Folder, FolderWithSubFolders } from '@proton/shared/lib/interfaces
 
 import type { MoveParams } from '../../hooks/actions/applyLocation/interface';
 import { useMailboxCounter } from '../../hooks/mailboxCounter/useMailboxCounter';
+import { useMailSettings } from '../../store/mailSettings/hooks';
 
 import type { ApplyLabelsParams } from '../../hooks/actions/label/interface';
 import SidebarFolder from './SidebarFolder';
@@ -34,6 +35,17 @@ const SidebarFolders = ({
     const onlyOneLevel = foldersTreeview.every((folder) => !folder.subfolders?.length);
     const emptyFolders = !loadingFolders && !folders?.length;
     const { getLocationCount } = useMailboxCounter();
+    const [mailSettings] = useMailSettings();
+
+    const getFolderUnreadCount = (folder: FolderWithSubFolders): number => {
+        return (
+            getLocationCount(folder.ID).Unread +
+            (folder.subfolders?.reduce(
+                (unreadCount, subfolder) => unreadCount + getFolderUnreadCount(subfolder as FolderWithSubFolders),
+                0
+            ) ?? 0)
+        );
+    };
 
     const treeviewReducer = (acc: ReactNode[], folder: FolderWithSubFolders, level = 0): any[] => {
         acc.push(
@@ -44,7 +56,11 @@ const SidebarFolders = ({
                 level={level}
                 onToggle={handleToggleFolder}
                 expanded={Boolean(folder.Expanded)}
-                unreadCount={getLocationCount(folder.ID).Unread}
+                unreadCount={
+                    mailSettings.IncludeSubfolderUnreadCount && !folder.Expanded
+                        ? getFolderUnreadCount(folder)
+                        : getLocationCount(folder.ID).Unread
+                }
                 id={folder.ID}
                 onFocus={updateFocusItem}
                 treeMode={!onlyOneLevel}

--- a/packages/components/containers/labels/FoldersSection.tsx
+++ b/packages/components/containers/labels/FoldersSection.tsx
@@ -27,6 +27,7 @@ import SettingsLayoutRight from '../account/SettingsLayoutRight';
 import SettingsSection from '../account/SettingsSection';
 import FolderTreeViewList from './FolderTreeViewList';
 import ToggleEnableFolderColor from './ToggleEnableFolderColor';
+import ToggleIncludeSubfolderUnreadCount from './ToggleIncludeSubfolderUnreadCount';
 import ToggleInheritParentFolderColor from './ToggleInheritParentFolderColor';
 import ConfirmSortModal from './modals/ConfirmSortModal';
 import EditLabelModal from './modals/EditLabelModal';
@@ -110,6 +111,17 @@ export default function FoldersSection({ showPromptOnAction = false }: Props) {
                             </SettingsLayoutRight>
                         </SettingsLayout>
                     ) : null}
+
+                    <SettingsLayout>
+                        <SettingsLayoutLeft>
+                            <label htmlFor="subfolder-unread-count" className="text-semibold">
+                                {c('Label').t`Include unread counts from subfolders`}
+                            </label>
+                        </SettingsLayoutLeft>
+                        <SettingsLayoutRight isToggleContainer>
+                            <ToggleIncludeSubfolderUnreadCount id="subfolder-unread-count" />
+                        </SettingsLayoutRight>
+                    </SettingsLayout>
 
                     <div className="flex gap-4 my-7 folders-action">
                         {canCreateFolder ? (

--- a/packages/components/containers/labels/ToggleIncludeSubfolderUnreadCount.tsx
+++ b/packages/components/containers/labels/ToggleIncludeSubfolderUnreadCount.tsx
@@ -1,0 +1,49 @@
+import type { ChangeEvent } from 'react';
+
+import { c } from 'ttag';
+
+import { useApi } from '@proton/app-context/useApi';
+import { useNotifications } from '@proton/app-context/useNotifications';
+import { useLoading } from '@proton/hooks';
+import { mailSettingsActions } from '@proton/mail/store/mailSettings';
+import { useMailSettings } from '@proton/mail/store/mailSettings/hooks';
+import { useDispatch } from '@proton/redux-shared-store/sharedProvider';
+import { updateIncludeSubfolderUnreadCount } from '@proton/shared/lib/api/mailSettings';
+import type { MailSettings } from '@proton/shared/lib/interfaces';
+
+import Toggle from '../../components/toggle/Toggle';
+
+interface Props {
+    id?: string;
+    className?: string;
+}
+
+const ToggleIncludeSubfolderUnreadCount = ({ id, className }: Props) => {
+    const api = useApi();
+    const { createNotification } = useNotifications();
+    const [loading, withLoading] = useLoading();
+    const [mailSettings] = useMailSettings();
+    const dispatch = useDispatch();
+
+    const handleChange = async ({ target }: ChangeEvent<HTMLInputElement>) => {
+        const { MailSettings } = await api<{ MailSettings: MailSettings }>(
+            updateIncludeSubfolderUnreadCount(+target.checked)
+        );
+        dispatch(mailSettingsActions.updateMailSettings(MailSettings));
+        createNotification({
+            text: c('label/folder notification').t`Preference saved`,
+        });
+    };
+
+    return (
+        <Toggle
+            id={id}
+            checked={mailSettings.IncludeSubfolderUnreadCount}
+            className={className}
+            onChange={(e) => withLoading(handleChange(e))}
+            loading={loading}
+        />
+    );
+};
+
+export default ToggleIncludeSubfolderUnreadCount;

--- a/packages/redux-shared-store/settingsHeartbeat/mailSettingsHeartbeatListener.ts
+++ b/packages/redux-shared-store/settingsHeartbeat/mailSettingsHeartbeatListener.ts
@@ -93,6 +93,7 @@ export const mailSettingsHeartbeatListener = (startListening: AppStartListening)
                     removeImageMetadata: formatBooleanForHeartbeat(mailSettings.RemoveImageMetadata),
                     pmSignatureReferral: formatBooleanForHeartbeat(mailSettings.PMSignatureReferralLink),
                     inheritParentFolderColor: formatBooleanForHeartbeat(mailSettings.InheritParentFolderColor),
+                    includeSubfolderUnreadCount: formatBooleanForHeartbeat(mailSettings.IncludeSubfolderUnreadCount),
                     categoryView: formatBooleanForHeartbeat(mailSettings.MailCategoryView),
                     showMoved: formatShowMoved(mailSettings.ShowMoved),
                     labelsCount: getArrayLengthRange(labels),

--- a/packages/shared/lib/api/mailSettings.ts
+++ b/packages/shared/lib/api/mailSettings.ts
@@ -195,6 +195,12 @@ export const updateInheritParentFolderColor = (InheritParentFolderColor: number)
     data: { InheritParentFolderColor },
 });
 
+export const updateIncludeSubfolderUnreadCount = (IncludeSubfolderUnreadCount: number) => ({
+    url: 'mail/v4/settings/includesubfolderunreadcount',
+    method: 'put',
+    data: { IncludeSubfolderUnreadCount },
+});
+
 export const updateFontFace = (FontFace: string) => ({
     url: 'mail/v4/settings/fontface',
     method: 'put',

--- a/packages/shared/lib/interfaces/MailSettings.ts
+++ b/packages/shared/lib/interfaces/MailSettings.ts
@@ -76,6 +76,7 @@ export interface MailSettings {
     DelaySendSeconds: DELAY_IN_SECONDS;
     EnableFolderColor: FOLDER_COLOR;
     InheritParentFolderColor: INHERIT_PARENT_FOLDER_COLOR;
+    IncludeSubfolderUnreadCount: boolean;
     /**
      * FontFace value is a FONT_FACES.${FONT}.id value or null.
      */

--- a/packages/shared/lib/mail/mailSettings.ts
+++ b/packages/shared/lib/mail/mailSettings.ts
@@ -214,6 +214,7 @@ export const DEFAULT_MAIL_SETTINGS: MailSettings & { _isDefault: boolean } = {
     DelaySendSeconds: DELAY_IN_SECONDS.MEDIUM,
     EnableFolderColor: FOLDER_COLOR.DISABLED,
     InheritParentFolderColor: INHERIT_PARENT_FOLDER_COLOR.ENABLED,
+    IncludeSubfolderUnreadCount: true,
     FontFace: null,
     FontSize: null,
     PMSignatureReferralLink: PM_SIGNATURE_REFERRAL.DISABLED,


### PR DESCRIPTION
Hello, first time trying something like this. It may not be efficient or usable as is since I'm not a coder. I hope it at least leads in the right direction. Please refer to the images provided for reference of targeted goal.

Goal: Ability to see overall unread email numbers without having to expand the custom folders.
Target: Web browser and Windows Desktop App. I would like to see this across all platforms but this is the best I can do for now.
Note: Unable to test because of native restrictions.

Images created through Visual Studio for visual:
<img width="1050" height="656" alt="Nesting Folder Unread Counts Screenshot" src="https://github.com/user-attachments/assets/6ccd99eb-5be6-4538-acce-28ca888f889f" />

Toggle for added customization: This can be off by default incase others don't want it.
<img width="745" height="383" alt="Folder and Label Screenshot" src="https://github.com/user-attachments/assets/66cf1544-25dc-44f3-9982-44bb8105cbe0" />